### PR TITLE
Turn PublicKey into a newtype wrapper

### DIFF
--- a/kolme/examples/cosmos-bridge.rs
+++ b/kolme/examples/cosmos-bridge.rs
@@ -39,7 +39,7 @@ impl KolmeApp for SampleKolmeApp {
     type Message = SampleMessage;
 
     fn genesis_info() -> GenesisInfo {
-        let my_public_key = my_secret_key().public_key();
+        let my_public_key = PublicKey(my_secret_key().public_key());
         let mut set = BTreeSet::new();
         set.insert(my_public_key);
         let mut bridges = BTreeMap::new();

--- a/kolme/src/core/execute.rs
+++ b/kolme/src/core/execute.rs
@@ -242,7 +242,6 @@ async fn has_already_listened(
     pubkey: &PublicKey,
 ) -> Result<bool> {
     let chain = chain.as_ref();
-    let pubkey = pubkey.to_sec1_bytes();
     let event_id = i64::try_from(event_id.0)?;
     let count = sqlx::query_scalar!(
         r#"

--- a/kolme/src/core/types.rs
+++ b/kolme/src/core/types.rs
@@ -1,7 +1,6 @@
 use std::{fmt::Display, sync::OnceLock};
 
 use crate::*;
-use k256::PublicKey;
 
 #[derive(
     serde::Serialize,

--- a/kolme/src/lib.rs
+++ b/kolme/src/lib.rs
@@ -8,7 +8,6 @@ mod submitter;
 pub use api_server::ApiServer;
 pub use common::*;
 pub use core::*;
-pub(crate) use k256::PublicKey;
 pub use listener::Listener;
 pub use processor::Processor;
 pub use submitter::Submitter;

--- a/kolme/src/listener.rs
+++ b/kolme/src/listener.rs
@@ -51,7 +51,7 @@ impl<App: KolmeApp> Listener<App> {
                 if !kolme
                     .received_listener_attestation(
                         chain,
-                        self.secret.public_key(),
+                        PublicKey(self.secret.public_key()),
                         BridgeEventId::start(),
                     )
                     .await?
@@ -98,7 +98,7 @@ async fn listen<App: KolmeApp>(
     let mut next_bridge_event_id = kolme
         .read()
         .await
-        .get_next_bridge_event_id(chain, secret.public_key())
+        .get_next_bridge_event_id(chain, PublicKey(secret.public_key()))
         .await?;
     tracing::info!(
         "Beginning listener loop on contract {contract}, next event ID: {next_bridge_event_id}"
@@ -170,9 +170,7 @@ async fn broadcast_listener_event<App: KolmeApp>(
                 });
             }
             for key in keys {
-                let key = hex::decode(key)?;
-                let key = PublicKey::from_sec1_bytes(&key)?;
-                new_keys.push(key);
+                new_keys.push(key.parse()?);
             }
 
             Message::Listener {

--- a/kolme/src/processor.rs
+++ b/kolme/src/processor.rs
@@ -113,7 +113,7 @@ impl<App: KolmeApp> Processor<App> {
         let approved_block = Block {
             tx,
             timestamp: now,
-            processor: self.secret.public_key(),
+            processor: PublicKey(self.secret.public_key()),
             height: next_event_height,
             parent: parent_hash,
             framework_state,

--- a/kolme/src/submitter.rs
+++ b/kolme/src/submitter.rs
@@ -63,16 +63,13 @@ impl<App: KolmeApp> Submitter<App> {
                 // TODO create a shared crate and use the same definitions in the contracts and this code
                 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone)]
                 struct InstantiateMsg {
-                    processor: String,
-                    executors: Vec<String>,
+                    processor: PublicKey,
+                    executors: Vec<PublicKey>,
                     needed_executors: u16,
                 }
                 let msg = InstantiateMsg {
-                    processor: hex::encode(processor.to_sec1_bytes()),
-                    executors: executors
-                        .into_iter()
-                        .map(|e| hex::encode(e.to_sec1_bytes()))
-                        .collect(),
+                    processor,
+                    executors: executors.into_iter().collect(),
                     needed_executors: needed_executors.try_into()?,
                 };
 

--- a/kolme/tests/offline-simple.rs
+++ b/kolme/tests/offline-simple.rs
@@ -35,7 +35,7 @@ impl KolmeApp for SampleKolmeApp {
     type Message = SampleMessage;
 
     fn genesis_info() -> GenesisInfo {
-        let my_public_key = get_sample_secret_key().public_key();
+        let my_public_key = PublicKey(get_sample_secret_key().public_key());
         let mut set = BTreeSet::new();
         set.insert(my_public_key);
         let mut bridges = BTreeMap::new();


### PR DESCRIPTION
It turns out that different methods on k256::PublicKey render the public key in different ways. Having our own newtype allows us to bypass that issue entirely.