### PR TITLE
Don't decode Binary as it does it itself

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1969,7 +1969,6 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "axum 0.8.1",
- "base64",
  "chrono",
  "clap",
  "cosmos",

--- a/kolme/Cargo.toml
+++ b/kolme/Cargo.toml
@@ -7,7 +7,6 @@ resolver = "2"
 [dependencies]
 anyhow = "1.0.97"
 axum = "0.8.1"
-base64 = "0.22.1"
 chrono = { version = "0.4.40", features = ["serde"] }
 clap = { version = "4.5.20", features = ["derive", "env", "unicode"] }
 cosmos = { git = "https://github.com/fpco/cosmos-rs", rev = "6f6fea0f7c04e4b64f5c091b006e4736dba1b10e", features = ["config"] }

--- a/kolme/src/listener.rs
+++ b/kolme/src/listener.rs
@@ -1,4 +1,3 @@
-use base64::{prelude::BASE64_STANDARD, Engine};
 use cosmos::Contract;
 use cosmwasm_std::Coin;
 use shared::cosmos::{BridgeEventMessage, GetEventResp, QueryMsg};
@@ -171,7 +170,6 @@ async fn listen_once<App: KolmeApp>(
         .await?
     {
         GetEventResp::Found { message } => {
-            let message = BASE64_STANDARD.decode(&message)?;
             let message = serde_json::from_slice::<BridgeEventMessage>(&message)?;
             broadcast_listener_event(kolme, secret, chain, *next_bridge_event_id, &message).await?;
             *next_bridge_event_id = next_bridge_event_id.next();


### PR DESCRIPTION
cosmwasm_std::Binary stores bytes internally but when
serializing/deserializing to JSON it uses base64 internally.
As a result extra decoding fails complaining about ASCII code 123
whichc corresponds to {
