### PR TITLE
Set "restart" to "no" for localosmosis and postgres containers in integration tests' compose

### DIFF
--- a/packages/integration-tests/docker-compose.yml
+++ b/packages/integration-tests/docker-compose.yml
@@ -10,7 +10,6 @@ services:
       - "127.0.0.1:9091:9091"
     volumes:
       - ./local-workspace:/var/workspace
-    restart: always
 
   postgres:
     container_name: postgres
@@ -21,4 +20,3 @@ services:
       POSTGRES_DB: postgres
     ports:
       - "127.0.0.1:5432:5432"
-    restart: always


### PR DESCRIPTION
Having [restart](https://docs.docker.com/reference/compose-file/services/#restart) parameter set to `always` could be a bit annoying because it keeps containers auto-restarted on system startup, etc.  Also, `localosmosis` container can generate up to 1000 log lines per second, which can eat decent amounts of disk space in the background. And `postgres` container can potentially conflict with other similar postgres containers deployed locally for other projects, because it uses  standard pg port (5432) on host machine.

- for both `localosmosis` and `postgres` remove `restart`  attribute, which resets it to default value of `no`