### PR TITLE
Use a different port for Dockerized PostgreSQL

### DIFF
--- a/justfile
+++ b/justfile
@@ -17,7 +17,7 @@ test: postgres
     cargo sqlx database reset -y --source packages/kolme/migrations
     cargo sqlx migrate run --source packages/kolme/migrations
     cargo sqlx prepare --workspace
-    PROCESSOR_BLOCK_DB=psql://postgres:postgres@localhost:5432/postgres cargo test
+    PROCESSOR_BLOCK_DB=psql://postgres:postgres@localhost:45921/postgres cargo test
 
 build-optimizer-image:
     ./.ci/build-optimizer-image.sh

--- a/packages/integration-tests/docker-compose.yml
+++ b/packages/integration-tests/docker-compose.yml
@@ -19,4 +19,4 @@ services:
       POSTGRES_PASSWORD: postgres
       POSTGRES_DB: postgres
     ports:
-      - "127.0.0.1:5432:5432"
+      - "127.0.0.1:45921:5432"


### PR DESCRIPTION
Minor quality of life improvement for me, I already run a PostgreSQL instance on my machine, so I was getting a port conflict.