### PR TITLE
Fix deadlocks in merkle-map

### DIFF
--- a/packages/merkle-map/src/manager.rs
+++ b/packages/merkle-map/src/manager.rs
@@ -151,6 +151,6 @@ impl MerkleManager {
         let Some(payload) = self.cache.read().get(&hash).cloned() else {
             return Ok(None);
         };
-        self.deserialize(hash, payload.clone()).map(Some)
+        self.deserialize(hash, payload).map(Some)
     }
 }


### PR DESCRIPTION
CC @psibi even more subtle deadlocks with parking-lot. I'm certain I was experiencing deadlocks from the second case (the deserialize_cached method). I'm pretty sure the case in the serialize method was broken too.