### PR TITLE
KolmeApp::state: add Debug trait requirement

### DIFF
--- a/packages/examples/cosmos-bridge/src/lib.rs
+++ b/packages/examples/cosmos-bridge/src/lib.rs
@@ -15,7 +15,7 @@ pub struct CosmosBridgeApp {
     pub genesis: GenesisInfo,
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Clone)]
+#[derive(serde::Serialize, serde::Deserialize, Clone, Debug)]
 pub struct State {
     #[serde(default)]
     hi_count: u32,

--- a/packages/examples/kademlia-discovery/src/lib.rs
+++ b/packages/examples/kademlia-discovery/src/lib.rs
@@ -11,7 +11,7 @@ pub struct KademliaTestApp {
     pub genesis: GenesisInfo,
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Clone)]
+#[derive(serde::Serialize, serde::Deserialize, Clone, Debug)]
 pub struct State {
     #[serde(default)]
     hi_count: u32,

--- a/packages/examples/p2p/src/lib.rs
+++ b/packages/examples/p2p/src/lib.rs
@@ -11,7 +11,7 @@ pub struct SampleKolmeApp {
     pub genesis: GenesisInfo,
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Clone)]
+#[derive(serde::Serialize, serde::Deserialize, Clone, Debug)]
 pub struct SampleState {
     #[serde(default)]
     hi_count: u32,

--- a/packages/examples/six-sigma/src/state.rs
+++ b/packages/examples/six-sigma/src/state.rs
@@ -10,7 +10,7 @@ use serde::Serialize;
 
 use crate::{AppState, BalanceChange, Odds, OUTCOME_COUNT};
 
-#[derive(Serialize, Clone)]
+#[derive(Serialize, Clone, Debug)]
 pub struct State {
     admin_keys: BTreeSet<PublicKey>,
     #[serde(serialize_with = "as_btree_map")]
@@ -78,7 +78,13 @@ impl State {
 const HOUSE_FUNDS: Decimal = dec!(1000); // 1000 coins with 6 decimals
 
 #[derive(
-    PartialEq, serde::Serialize, serde::Deserialize, Clone, strum::AsRefStr, strum::EnumString,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    Clone,
+    strum::AsRefStr,
+    strum::EnumString,
+    Debug,
 )]
 pub enum MarketState {
     Operational,
@@ -105,7 +111,7 @@ impl MerkleDeserialize for MarketState {
     }
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Clone)]
+#[derive(serde::Serialize, serde::Deserialize, Clone, Debug)]
 pub struct Market {
     pub state: MarketState,
     id: u64,
@@ -165,7 +171,7 @@ impl MerkleDeserialize for Market {
     }
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Clone)]
+#[derive(serde::Serialize, serde::Deserialize, Clone, Debug)]
 pub struct Bet {
     bettor: AccountId,
     wallet: Wallet,

--- a/packages/examples/solana-cosmos-bridge/src/lib.rs
+++ b/packages/examples/solana-cosmos-bridge/src/lib.rs
@@ -16,7 +16,7 @@ pub struct SolanaCosmosBridgeApp {
     pub genesis: GenesisInfo,
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Clone, Copy, Default)]
+#[derive(serde::Serialize, serde::Deserialize, Clone, Copy, Default, Debug)]
 pub struct State;
 
 impl MerkleSerialize for State {

--- a/packages/kolme/src/core/kolme_app.rs
+++ b/packages/kolme/src/core/kolme_app.rs
@@ -3,7 +3,13 @@ use crate::*;
 pub trait KolmeApp: Send + Sync + Clone + 'static {
     /// The state maintained in memory, may contain helper
     /// data structures for more efficient operations.
-    type State: MerkleSerialize + MerkleDeserialize + Send + Sync + Clone + 'static;
+    type State: MerkleSerialize
+        + MerkleDeserialize
+        + Send
+        + Sync
+        + Clone
+        + std::fmt::Debug
+        + 'static;
 
     /// Messages that are understood by this app.
     type Message: serde::Serialize

--- a/packages/kolme/tests/multiple-processors.rs
+++ b/packages/kolme/tests/multiple-processors.rs
@@ -14,7 +14,7 @@ pub struct SampleKolmeApp {
     pub genesis: GenesisInfo,
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Clone)]
+#[derive(serde::Serialize, serde::Deserialize, Clone, Debug)]
 pub struct SampleState {}
 
 impl MerkleSerialize for SampleState {

--- a/packages/kolme/tests/offline-simple.rs
+++ b/packages/kolme/tests/offline-simple.rs
@@ -11,7 +11,7 @@ pub struct SampleKolmeApp {
     pub genesis: GenesisInfo,
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Clone)]
+#[derive(serde::Serialize, serde::Deserialize, Clone, Debug)]
 pub struct SampleState {}
 
 impl MerkleSerialize for SampleState {

--- a/packages/kolme/tests/p2p.rs
+++ b/packages/kolme/tests/p2p.rs
@@ -11,7 +11,7 @@ pub struct SampleKolmeApp {
     pub genesis: GenesisInfo,
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Clone)]
+#[derive(serde::Serialize, serde::Deserialize, Clone, Debug)]
 pub struct SampleState {
     #[serde(default)]
     hi_count: u32,


### PR DESCRIPTION
In order to do some debugging, I've added Debug trait requirement to KolmeApp::State.

This required to add Debug trait cascadingly to all `State` types and some more, like `six-sigma::Market` and `six-sigma::Bet`