### PR TITLE
Use release build in CI for more reliable time-based testing

### DIFF
--- a/justfile
+++ b/justfile
@@ -14,9 +14,9 @@ postgres:
     docker compose -f ./packages/integration-tests/docker-compose.yml up -d postgres
 
 test: setup-localosmo
-    PROCESSOR_BLOCK_DB=psql://postgres:postgres@localhost:45921/postgres cargo test
+    PROCESSOR_BLOCK_DB=psql://postgres:postgres@localhost:45921/postgres cargo test --release
     just kademlia-test
-    cd packages/integration-tests && cargo test -- --nocapture
+    cd packages/integration-tests && cargo test --release -- --nocapture
 
 [working-directory: "packages/kolme-store-postgresql"]
 sqlx-prepare $DATABASE_URL="postgres://postgres:postgres@localhost:45921/postgres": postgres

--- a/packages/examples/kademlia-discovery/test.sh
+++ b/packages/examples/kademlia-discovery/test.sh
@@ -2,9 +2,9 @@
 
 set -euxo pipefail
 
-cargo build
+cargo build --release
 
 docker rm -f kademlia-test-validators
 trap "docker rm -f kademlia-test-validators" EXIT
-docker run --rm -d --name kademlia-test-validators -p 5400:5400 -v "$(pwd)/../../../target/debug":/host:ro ubuntu /host/kademlia-discovery validators 5400
-cargo run client /ip4/127.0.0.1/udp/5400/quic-v1
+docker run --rm -d --name kademlia-test-validators -p 5400:5400 -v "$(pwd)/../../../target/release":/host:ro ubuntu /host/kademlia-discovery validators 5400
+cargo run --release client /ip4/127.0.0.1/udp/5400/quic-v1


### PR DESCRIPTION
A number of tests were flaky previously because processing time for a block was too high. Part of the investigation in #224.