### PR TITLE
kademlia-discovery: use DNS name for bootstrapping

### DIFF
--- a/packages/examples/kademlia-discovery/Cargo.toml
+++ b/packages/examples/kademlia-discovery/Cargo.toml
@@ -9,5 +9,5 @@ rand = "0.8"
 tokio = { workspace = true }
 clap = { workspace = true }
 kolme = { workspace = true }
-libp2p = { workspace = true, features = ["rsa"] }
+libp2p = { workspace = true, features = ["rsa", "dns"] }
 anyhow = { workspace = true }

--- a/packages/kolme/src/gossip.rs
+++ b/packages/kolme/src/gossip.rs
@@ -161,6 +161,7 @@ impl GossipBuilder {
                 yamux::Config::default,
             )?
             .with_quic()
+            .with_dns()?
             .with_behaviour(|key| {
                 tracing::info!(
                     "Creating new gossip, running as peer ID: {}",

--- a/packages/kolme/tests/kademlia.rs
+++ b/packages/kolme/tests/kademlia.rs
@@ -19,7 +19,7 @@ async fn kademlia_discovery_inner(testtasks: TestTasks, (): ()) {
 }
 
 async fn kademlia_discovery_client(port: u16, signing_secret: SecretKey) -> Result<()> {
-    client(&format!("/ip4/127.0.0.1/tcp/{port}"), signing_secret)
+    client(&format!("/dns4/localhost/tcp/{port}"), signing_secret)
         .await
         .unwrap();
     Ok(())


### PR DESCRIPTION
This is just a demo for the sake of not losing a bit of knowledge I discovered while exploring libp2p - getting to know how to use DNS was a bit tricky, but actually using it is a lot simpler. 
I believe, in future we could benefit from connecting to bootstrap nodes via DNS names.
Although, we don't need this code at the moment, thus PR is draft.