### PR TITLE
Lower log level for InsufficientPeers error

### DIFF
--- a/packages/kolme/src/gossip/messages.rs
+++ b/packages/kolme/src/gossip/messages.rs
@@ -121,6 +121,13 @@ impl<App: KolmeApp> GossipMessage<App> {
                 );
                 Ok(())
             }
+            Err(PublishError::InsufficientPeers) => {
+                tracing::info!(
+                    "{}: Not enough peers to send this message to",
+                    gossip.local_display_name
+                );
+                Ok(())
+            }
             Err(err) => Err(err).with_context(|| {
                 format!(
                     "{}: Unable to publish a gossipsub message: {self}",


### PR DESCRIPTION
It's expected that we could have no peers at least at the start up
thus in takes sense to lower the level of log message in this case and
decrease its verbosity as well
