### PR TITLE
Kademlia tests use in-memory store

### DIFF
--- a/packages/examples/kademlia-discovery/src/lib.rs
+++ b/packages/examples/kademlia-discovery/src/lib.rs
@@ -118,13 +118,11 @@ impl<App> KolmeDataRequest<App> for RandomU32 {
 pub async fn validators(port: u16) -> Result<()> {
     const VALIDATOR_KEYPAIR_BYTES: &[u8] = include_bytes!("../assets/validator-keypair.pk8");
 
-    const DB_PATH: &str = "kademlia-test.fjall";
-
     kolme::init_logger(true, None);
     let kolme = Kolme::new(
         KademliaTestApp::default(),
         DUMMY_CODE_VERSION,
-        KolmeStore::new_fjall(DB_PATH)?,
+        KolmeStore::new_in_memory(),
     )
     .await?;
 


### PR DESCRIPTION
Currently, we're using a static directory, which (1) pollutes the working tree and (2) leads to conflicts when changing serialization format. We could use a temp dir instead, but the reality is that we don't need to test Fjall as part of the Kademlia tests, so moving to in-memory makes more sense.