### PR TITLE
Use snake_case for enum serialization

### DIFF
--- a/packages/examples/six-sigma/src/state.rs
+++ b/packages/examples/six-sigma/src/state.rs
@@ -87,6 +87,7 @@ const HOUSE_FUNDS: Decimal = dec!(1000); // 1000 coins with 6 decimals
     strum::EnumString,
     Debug,
 )]
+#[serde(rename_all = "snake_case")]
 pub enum MarketState {
     Operational,
     Settled,

--- a/packages/examples/six-sigma/src/types.rs
+++ b/packages/examples/six-sigma/src/types.rs
@@ -43,6 +43,7 @@ pub enum AppMessage {
 }
 
 #[derive(PartialEq, serde::Serialize, serde::Deserialize, Debug)]
+#[serde(rename_all = "snake_case")]
 pub enum LogOutput {
     NewBlock {
         height: BlockHeight,
@@ -53,6 +54,7 @@ pub enum LogOutput {
 
 // kolme::Message with details only necessary for tests
 #[derive(PartialEq, serde::Serialize, serde::Deserialize, Debug)]
+#[serde(rename_all = "snake_case")]
 pub enum LoggedMessage {
     Genesis,
     App(AppMessage),
@@ -80,6 +82,7 @@ impl From<kolme::Message<AppMessage>> for LoggedMessage {
 }
 
 #[derive(PartialEq, serde::Serialize, serde::Deserialize, Debug)]
+#[serde(rename_all = "snake_case")]
 pub enum LoggedBridgeEvent {
     Instantiated,
     Regular,
@@ -106,6 +109,7 @@ impl From<kolme::BridgeEvent> for LoggedBridgeEvent {
     strum::AsRefStr,
     strum::EnumString,
 )]
+#[serde(rename_all = "snake_case")]
 #[strum(serialize_all = "snake_case")]
 pub enum AppState {
     #[default]

--- a/packages/integration-tests/tests/balances.rs
+++ b/packages/integration-tests/tests/balances.rs
@@ -37,6 +37,7 @@ impl MerkleDeserialize for SampleState {
 }
 
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug)]
+#[serde(rename_all = "snake_case")]
 pub enum SampleMessage {
     GiveOsmo { amount: Decimal },
 }

--- a/packages/integration-tests/tests/six-sigma.rs
+++ b/packages/integration-tests/tests/six-sigma.rs
@@ -469,6 +469,7 @@ struct Market {
 }
 
 #[derive(PartialEq, serde::Deserialize, Debug)]
+#[serde(rename_all = "snake_case")]
 enum MarketState {
     Operational,
     Settled,

--- a/packages/kolme/src/core/types.rs
+++ b/packages/kolme/src/core/types.rs
@@ -1647,6 +1647,7 @@ pub struct LatestBlock {
 
 /// Represents distinct occurrences in the core of Kolme that could be relevant to users.
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
 pub enum LogEvent {
     ProcessedBridgeEvent(LogBridgeEvent),
     NewAdminProposal(AdminProposalId),

--- a/packages/kolme/tests/multiple-processors.rs
+++ b/packages/kolme/tests/multiple-processors.rs
@@ -37,6 +37,7 @@ impl MerkleDeserialize for SampleState {
 }
 
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug)]
+#[serde(rename_all = "snake_case")]
 pub enum SampleMessage {
     SayHi,
 }

--- a/packages/kolme/tests/offline-simple.rs
+++ b/packages/kolme/tests/offline-simple.rs
@@ -33,6 +33,7 @@ impl MerkleDeserialize for SampleState {
 }
 
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug)]
+#[serde(rename_all = "snake_case")]
 pub enum SampleMessage {
     SayHi,
 }

--- a/packages/kolme/tests/validations.rs
+++ b/packages/kolme/tests/validations.rs
@@ -36,6 +36,7 @@ impl MerkleDeserialize for SampleState {
 }
 
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug)]
+#[serde(rename_all = "snake_case")]
 pub enum SampleMessage {
     SayHi,
 }


### PR DESCRIPTION
I noticed this when working on #317. Not a huge deal, but would be good to be consistent. I tried to cover the test cases too (and, in fact, most of the changes _are_ for the test cases), but if I missed some, that's not such a big deal.