### PR TITLE
build: Remove linker line from cargo configuration

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,3 +1,2 @@
 [build]
-linker = "clang"
 rustflags = ["-C", "link-arg=-fuse-ld=mold"]


### PR DESCRIPTION
Right now for any type of build I do, I'm greeted with this warning:

```
warning: unused config key `build.linker` in
`/home/sibi/fpco/github/kolme/.cargo/config.toml`
```

And looks like it's the same case in CI too:
https://github.com/fpco/kolme/actions/runs/15899369196/job/44838490755