### PR TITLE
fix: more controlled concurrency in state sync

### DIFF
--- a/packages/shared/src/types.rs
+++ b/packages/shared/src/types.rs
@@ -90,7 +90,7 @@ mod cw_impls {
 }
 
 /// A binary value representing a SHA256 hash.
-#[derive(PartialEq, Eq, Hash, Clone, Copy)]
+#[derive(PartialEq, Eq, Hash, Clone, Copy, PartialOrd, Ord)]
 pub struct Sha256Hash([u8; 32]);
 
 #[derive(thiserror::Error, Debug)]


### PR DESCRIPTION
Previously, gossip's state sync mechanism would essentially blast as many requests as quickly as possible to try and synchronize the chain. It turns out that this doesn't work well with libp2p's backpressure mechanism, essentially causing syncing to fail.

This new approach instead is much more controlled. It keeps exactly 1 active block being requested and up to REQUEST_COUNT (currently 4) merkle layers, and waits 2 seconds before resubmitting a request.

This appears to address all issues raised in KOL-30.