### PR TITLE
fix: Adds consume_stores on add_merkle_layer

### DIFF
--- a/packages/kolme-store/src/postgres.rs
+++ b/packages/kolme-store/src/postgres.rs
@@ -426,7 +426,10 @@ impl KolmeBackingStore for Store {
         layer: &MerkleLayerContents,
     ) -> anyhow::Result<()> {
         let mut merkle = self.new_store();
-        Ok(merkle.save_by_hash(hash, layer).await?)
+        merkle.save_by_hash(hash, layer).await?;
+        self.consume_stores(&self.pool, [merkle]).await?;
+
+        Ok(())
     }
 
     async fn save<T: MerkleSerializeRaw>(


### PR DESCRIPTION
Before, merkle layer contents weren't persisted to the database as `consume_stores` was not being called