### PR TITLE
fix: resolve nondeterministic test failure from errant add

### DIFF
--- a/packages/kolme/src/gossip/state_sync.rs
+++ b/packages/kolme/src/gossip/state_sync.rs
@@ -281,8 +281,9 @@ impl<App: KolmeApp> StateSyncStatus<App> {
             }
             if self.pending_layers.contains_key(hash) || self.kolme.has_merkle_hash(*hash).await? {
                 to_remove.push(*hash);
+            } else {
+                self.active_layers.push(*hash);
             }
-            self.active_layers.push(*hash);
         }
         for hash in to_remove {
             self.needed_layers.remove(&hash);


### PR DESCRIPTION
The code was mistakenly adding a layer to the list of active layers for download even if it was already downloaded. This resulted in triggering a debug assertion that ensured we never ended up with an active layer that wasn't needed.