### PR TITLE
Switch MerkleManager to use LruCache instead on unbounded HashMap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4839,6 +4839,7 @@ dependencies = [
  "arrayvec",
  "base64 0.22.1",
  "jiff",
+ "lru 0.14.0",
  "parameterized",
  "parking_lot",
  "paste",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ libp2p = { version = "0.55" }
 merkle-map = { path = "packages/merkle-map" }
 quickcheck = "1.0.3"
 shared = { path = "packages/shared" }
+lru = "0.14.0"
 
 [workspace.lints.clippy]
 unused_async = "deny"

--- a/packages/kolme/Cargo.toml
+++ b/packages/kolme/Cargo.toml
@@ -41,7 +41,7 @@ tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
 kolme-solana-bridge-client = { path = "../../solana/crates/kolme-solana-bridge-client" }
 tokio-tungstenite = { version = "0.26.2", optional = true }
 futures-util = {version = "0.3", optional = true }
-lru = "0.14.0"
+lru.workspace = true
 hex.workspace = true
 
 [lints]

--- a/packages/kolme/src/core/kolme.rs
+++ b/packages/kolme/src/core/kolme.rs
@@ -82,6 +82,11 @@ impl<App: KolmeApp> Clone for Kolme<App> {
     }
 }
 
+// ATM we use a speculative cache bound. For cache values with avarage size of 1kb
+// and assuming pessimistic overhead of 2x this should result in merkle cache
+// not getting larger than 512M
+const MERKLE_CACHE_SIZE: usize = 262_144; // 2^^18
+
 impl<App: KolmeApp> Kolme<App> {
     /// Lock the local storage and the database.
     ///
@@ -621,7 +626,7 @@ impl<App: KolmeApp> Kolme<App> {
     ) -> Result<Self> {
         // FIXME in the future do some validation of code version, and allow
         // for explicit events for upgrading to a newer code version
-        let merkle_manager = MerkleManager::default();
+        let merkle_manager = MerkleManager::new(MERKLE_CACHE_SIZE);
         let current_block =
             MaybeBlockInfo::<App>::load(&store, app.genesis_info(), &merkle_manager).await?;
         let inner = KolmeInner {

--- a/packages/kolme/src/core/types.rs
+++ b/packages/kolme/src/core/types.rs
@@ -1799,7 +1799,7 @@ mod tests {
         ($value_type: ty, $test_name: ident) => {
             quickcheck! {
                 fn $test_name(value: $value_type) -> quickcheck::TestResult {
-                    let manager = MerkleManager::default();
+                    let manager = MerkleManager::new(1024);
                     let serialized = manager.serialize(&value).unwrap();
                     let deserialized = manager
                         .deserialize::<$value_type>(serialized.hash, serialized.payload.clone())

--- a/packages/merkle-map/Cargo.toml
+++ b/packages/merkle-map/Cargo.toml
@@ -16,6 +16,7 @@ thiserror = "2.0.12"
 tinyvec = { version = "1.9.0", features = ["alloc"] }
 jiff = { workspace = true }
 smallvec = { workspace = true }
+lru.workspace = true
 
 [dev-dependencies]
 paste = "1.0.15"

--- a/packages/merkle-map/tests/version.rs
+++ b/packages/merkle-map/tests/version.rs
@@ -204,7 +204,7 @@ async fn load_from_zero_helper(people: Vec<Person0>, to_modify: usize, new_stree
         m2.insert(idx, Person2::from(person));
     }
 
-    let manager = MerkleManager::default();
+    let manager = MerkleManager::new(1024);
     let mut store = MerkleMemoryStore::default();
     let m0_contents = manager.save(&mut store, &m0).await.unwrap();
 


### PR DESCRIPTION
As a first step we'll set a speculative bound of 256k entries. Later
we could do tests or measuring production values to ensure that we get
a good hit rate (and make it tunable in client code)
