### PR TITLE
chore: Clean up benchmark dependencies and justfiles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ wasm/
 test-ledger/
 flake.nix
 flake.lock
+.dir-locals.el

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -906,35 +906,24 @@ name = "benchmarks"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "axum 0.8.4",
- "backon",
- "cosmwasm-std",
  "criterion",
  "example-six-sigma",
  "example-solana-cosmos-bridge",
  "fjall",
- "futures",
- "futures-util",
- "hex",
  "jiff",
  "kolme",
  "merkle-map",
  "parking_lot",
  "plotters",
  "plotters-svg",
- "pretty_assertions",
  "rand 0.8.5",
  "regex",
  "serde",
  "serde_json",
- "serial_test",
  "smallvec",
  "sqlx",
- "strum 0.27.1",
  "tempdir",
- "tempfile",
  "tokio",
- "tokio-tungstenite 0.26.2",
  "tracing",
 ]
 
@@ -7308,15 +7297,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "scc"
-version = "2.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22b2d775fb28f245817589471dd49c5edf64237f4a19d10ce9a92ff4651a27f4"
-dependencies = [
- "sdd",
-]
-
-[[package]]
 name = "schannel"
 version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7370,12 +7350,6 @@ dependencies = [
  "ring",
  "untrusted",
 ]
-
-[[package]]
-name = "sdd"
-version = "3.0.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62f5557d2bbddd5afd236ba7856b0e494f5acc7ce805bb0774cc5674b20a06b4"
 
 [[package]]
 name = "seahash"
@@ -7619,31 +7593,6 @@ checksum = "a84f14a19e9a014bb9f4512488d9829a68e04ecabffb0f9904cd1ace94598177"
 dependencies = [
  "base16ct",
  "serde",
-]
-
-[[package]]
-name = "serial_test"
-version = "3.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b258109f244e1d6891bf1053a55d63a5cd4f8f4c30cf9a1280989f80e7a1fa9"
-dependencies = [
- "futures",
- "log",
- "once_cell",
- "parking_lot",
- "scc",
- "serial_test_derive",
-]
-
-[[package]]
-name = "serial_test_derive"
-version = "3.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d69265a08751de7844521fd15003ae0a888e035773ba05695c5c759a6f89eef"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.101",
 ]
 
 [[package]]

--- a/justfile
+++ b/justfile
@@ -1,12 +1,16 @@
+# List all dependencies
 default:
-    just --list
+    just --list --unsorted
 
+# Clippy check
 cargo-clippy-check:
 	cargo clippy --no-deps --workspace --locked --tests --benches --examples -- -Dwarnings
 
+# Rustfmt check
 cargo-fmt-check:
     cargo fmt --all --check
 
+# Format Rust code
 fmt:
 	cargo fmt --all
 

--- a/packages/benchmarks/Cargo.toml
+++ b/packages/benchmarks/Cargo.toml
@@ -23,19 +23,8 @@ plotters-svg = { version = "0.3.7", optional = true }
 regex = "1.11.1"
 example-six-sigma = { path = "../examples/six-sigma" }
 example-solana-cosmos-bridge = { path = "../examples/solana-cosmos-bridge" }
-strum = { version = "0.27.1", features = ["derive"] }
-futures = "0.3.31"
-backon = "1.4.1"
-hex = { workspace = true }
-cosmwasm-std = "2.2.2"
-tempfile = "3.19.1"
-pretty_assertions = "1.4.1"
 rand = "0.8"
-axum = { version = "0.8.3", features = ["ws"] }
-futures-util = "0.3.31"
-tokio-tungstenite = "0.26.2"
 jiff = "0.2.5"
-serial_test = "3.2.0"
 sqlx = { version = "0.8.6", features = ["postgres", "runtime-tokio"] }
 criterion = { version = "0.6.0", features = ["async_tokio"] }
 merkle-map.workspace = true

--- a/packages/benchmarks/justfile
+++ b/packages/benchmarks/justfile
@@ -1,8 +1,9 @@
-set positional-arguments
+set fallback := true
+set positional-arguments := true
 
-profile-insertions \
-    insertion_filter \
-    reserialization_filter \
-    $DATABASE_URL="postgres://postgres:postgres@localhost:45921/postgres" \
-    $SQLX_OFFLINE="true":
+# List all recipes
+default:
+	just --list --unsorted
+
+profile-insertions insertion_filter reserialization_filter $DATABASE_URL="postgres://postgres:postgres@localhost:45921/postgres" $SQLX_OFFLINE="true":
     CARGO_PROFILE_BENCH_DEBUG=true INITIAL_FILTER_REGEX="$1" RESERIALIZATION_FILTER_REGEX="$2" cargo flamegraph --bench insertion -- --bench


### PR DESCRIPTION
This commit reduces the dependency footprint of the `benchmarks` package by removing several unused libraries from its `Cargo.toml`.