### PR TITLE
feat: track "last gossiped" for mempool entries

### DIFF
--- a/packages/kolme/src/core/kolme/mempool.rs
+++ b/packages/kolme/src/core/kolme/mempool.rs
@@ -1,4 +1,8 @@
-use std::{collections::VecDeque, sync::Arc};
+use std::{
+    collections::VecDeque,
+    sync::Arc,
+    time::{Duration, Instant},
+};
 
 use parking_lot::RwLock;
 use utils::trigger::{Trigger, TriggerSubscriber};
@@ -8,24 +12,32 @@ use crate::*;
 pub struct Mempool<AppMessage> {
     txs: Arc<RwLock<Queue<AppMessage>>>,
     notify: Trigger,
+    gossip_delay_duration: Duration,
 }
 
-type Queue<AppMessage> = VecDeque<(TxHash, Arc<SignedTransaction<AppMessage>>)>;
+type Queue<AppMessage> = VecDeque<MempoolItem<AppMessage>>;
+
+struct MempoolItem<AppMessage> {
+    tx: Arc<SignedTransaction<AppMessage>>,
+    last_gossiped: Option<Instant>,
+}
 
 impl<AppMessage> Clone for Mempool<AppMessage> {
     fn clone(&self) -> Self {
         Self {
             txs: self.txs.clone(),
             notify: self.notify.clone(),
+            gossip_delay_duration: self.gossip_delay_duration,
         }
     }
 }
 
 impl<AppMessage> Mempool<AppMessage> {
-    pub(super) fn new() -> Self {
+    pub(super) fn new(gossip_delay_duration: Duration) -> Self {
         Self {
             txs: Default::default(),
             notify: Trigger::new("mempool"),
+            gossip_delay_duration,
         }
     }
 
@@ -39,31 +51,28 @@ impl<AppMessage> Mempool<AppMessage> {
         }
     }
 
-    pub(super) async fn peek(&self) -> (TxHash, Arc<SignedTransaction<AppMessage>>) {
-        if let Some(pair) = self.txs.read().front() {
-            return pair.clone();
+    pub(super) async fn peek(&self) -> Arc<SignedTransaction<AppMessage>> {
+        if let Some(item) = self.txs.read().front() {
+            return item.tx.clone();
         }
 
         let mut recv = self.notify.subscribe();
 
         loop {
-            if let Some(pair) = self.txs.read().front() {
-                break pair.clone();
+            if let Some(item) = self.txs.read().front() {
+                break item.tx.clone();
             }
             recv.listen().await;
         }
     }
 
     pub(super) fn drop_tx(&self, hash: TxHash) {
-        let mut guard = self.txs.write();
         let mut modified = false;
-        let mut i = 0;
-        while i < guard.len() {
-            if guard[i].0 == hash {
+        let mut guard = self.txs.write();
+        for idx in (0..guard.len()).rev() {
+            if guard[idx].tx.hash() == hash {
+                guard.swap_remove_back(idx);
                 modified = true;
-                guard.remove(i);
-            } else {
-                i += 1;
             }
         }
         if modified {
@@ -72,7 +81,10 @@ impl<AppMessage> Mempool<AppMessage> {
     }
 
     pub(super) fn add(&self, tx: Arc<SignedTransaction<AppMessage>>) {
-        self.txs.write().push_back((tx.hash(), tx));
+        self.txs.write().push_back(MempoolItem {
+            tx,
+            last_gossiped: None,
+        });
         self.notify.trigger();
     }
 
@@ -83,6 +95,36 @@ impl<AppMessage> Mempool<AppMessage> {
     }
 
     pub(super) fn get_entries(&self) -> Vec<Arc<SignedTransaction<AppMessage>>> {
-        self.txs.read().iter().map(|(_, tx)| tx.clone()).collect()
+        self.txs.read().iter().map(|item| item.tx.clone()).collect()
+    }
+
+    pub(crate) fn get_entries_for_gossip(&self) -> Vec<Arc<SignedTransaction<AppMessage>>> {
+        let mut cutoff = Instant::now();
+        cutoff = cutoff
+            .checked_sub(self.gossip_delay_duration)
+            .unwrap_or(cutoff);
+        self.txs
+            .read()
+            .iter()
+            .filter_map(|item| {
+                let to_gossip = item
+                    .last_gossiped
+                    .map_or(true, |last_gossiped| last_gossiped < cutoff);
+                if to_gossip {
+                    Some(item.tx.clone())
+                } else {
+                    None
+                }
+            })
+            .collect()
+    }
+
+    pub(crate) fn mark_mempool_entry_gossiped(&self, txhash: TxHash) {
+        let mut guard = self.txs.write();
+        for idx in (0..guard.len()).rev() {
+            if guard[idx].tx.hash() == txhash {
+                guard[idx].last_gossiped = Some(Instant::now());
+            }
+        }
     }
 }


### PR DESCRIPTION
This enforces a delay before resubmitting transactions.