### PR TITLE
test: Add logger to tx_evicted_mempool test

### DIFF
--- a/packages/kolme/tests/tx-evicted-mempool.rs
+++ b/packages/kolme/tests/tx-evicted-mempool.rs
@@ -95,6 +95,7 @@ impl KolmeApp for SampleKolmeApp {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn tx_evicted_mempool() {
+    init_logger(true, None);
     TestTasks::start(tx_evicted_inner, ()).await;
 }
 


### PR DESCRIPTION
This change initializes the logger within the 'tx_evicted_mempool' test function. Enabling the logger provides detailed output during test execution for debugging.