### PR TITLE
ci: Enforce warnings and cache keys

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,7 @@ env:
   CARGO_NET_RETRY: 10
   RUST_BACKTRACE: 1
   RUSTUP_MAX_RETRIES: 10
+  RUSTFLAGS: "-D warnings"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -37,7 +38,7 @@ jobs:
           components: rustfmt, clippy
       - uses: Swatinem/rust-cache@v2
         with:
-          prefix-key: "v0-kolme"
+          prefix-key: "v1-kolme"
           cache-workspace-crates: true
           cache-on-failure: true
           workspaces: |
@@ -94,7 +95,7 @@ jobs:
       - name: Rust cache
         uses: Swatinem/rust-cache@v2
         with:
-          prefix-key: "v5-solana"
+          prefix-key: "v6-solana"
           cache-workspace-crates: true
           # https://github.com/Swatinem/rust-cache/issues/237
           cache-bin: false

--- a/justfile
+++ b/justfile
@@ -46,6 +46,7 @@ sqlx-prepare $DATABASE_URL="postgres://postgres:postgres@localhost:45921/postgre
     just store::sqlx-prepare
     just kolme_test::sqlx-prepare
 
+# Build contracts
 build-contracts:
     ./.ci/build-contracts.sh
 


### PR DESCRIPTION
The CI workflow is updated to enforce stricter compilation for Rust projects. By adding the `RUSTFLAGS: "-D warnings"`, all Rust warnings will now be treated as errors. The primary motivation is to reduce the CI time: We pass this option during the clippy step which causes more work.

*   Add `RUSTFLAGS: "-D warnings"` to treat all Rust warnings as errors.
*   Update `rust-cache` prefix keys for `kolme` and `solana` workspaces so that fresh cache is generated. I believe the current
cache size is bigger than it's supposed to be because of my various experiments over the last week.

Edit: Looks like my cache size theory was right. It reduced from 3 GB to 1 GB. Now the CI time is less than 4 minutes. :-)