### PR TITLE
Kol 55 connection starvation debug

### DIFF
--- a/packages/integration-tests/tests/testapp.rs
+++ b/packages/integration-tests/tests/testapp.rs
@@ -153,8 +153,8 @@ async fn setup_postgres() -> Result<(Kolme<TestApp>, SocketAddr)> {
 
     let store = KolmeStore::new_postgres_with_options(
         options,
-        PgPoolOptions::new().max_connections(2),
-        1024,
+        PgPoolOptions::new().max_connections(3),
+        1,
     )
     .await?;
     let code_version = app.genesis.version.clone();

--- a/packages/integration-tests/tests/testapp.rs
+++ b/packages/integration-tests/tests/testapp.rs
@@ -151,12 +151,9 @@ async fn setup_postgres() -> Result<(Kolme<TestApp>, SocketAddr)> {
         .await
         .expect("Unable to run migrations");
 
-    let store = KolmeStore::new_postgres_with_options(
-        options,
-        PgPoolOptions::new().max_connections(3),
-        1,
-    )
-    .await?;
+    let store =
+        KolmeStore::new_postgres_with_options(options, PgPoolOptions::new().max_connections(3), 1)
+            .await?;
     let code_version = app.genesis.version.clone();
     let kolme = Kolme::new(app, code_version, store).await?;
 

--- a/packages/kolme-store/src/postgres.rs
+++ b/packages/kolme-store/src/postgres.rs
@@ -61,7 +61,6 @@ impl Store {
         options: PoolOptions<Postgres>,
         cache_size: usize,
     ) -> anyhow::Result<Self> {
-        anyhow::ensure!(cache_size >= 1024, "PostgreSQL backend currently requires a cache size of at least 1024. This is an open bug that needs investigation.");
         let pool = options
             .connect_with(connect)
             .await


### PR DESCRIPTION
- Removes cache size limitation to Postgres store
- Updates `test_concurrent_transactions_postgres` postgres pool to use an increased amount of max connections