### PR TITLE
feat: Implement basic healthz API endpoint

### DIFF
--- a/packages/kolme/src/api_server.rs
+++ b/packages/kolme/src/api_server.rs
@@ -65,6 +65,7 @@ pub fn base_api_router<App: KolmeApp>() -> axum::Router<Kolme<App>> {
         .route("/block/{height}", get(get_block))
         .route("/notifications", get(ws_handler::<App>))
         .route("/account-id/wallet/{wallet}", get(account_id_for_wallet))
+        .route("/healthz", get(healthz))
 }
 
 async fn basics<App: KolmeApp>(State(kolme): State<Kolme<App>>) -> impl IntoResponse {
@@ -93,6 +94,10 @@ async fn basics<App: KolmeApp>(State(kolme): State<Kolme<App>>) -> impl IntoResp
     };
 
     Json(basics).into_response()
+}
+
+async fn healthz() -> &'static str {
+    "Healthy!"
 }
 
 async fn broadcast<App: KolmeApp>(


### PR DESCRIPTION
This commit introduces a new `/healthz` endpoint to the Kolme API server. This simple endpoint provides a basic liveness check, returning a static "Healthy!" response. It is intended to be used by load balancers to verify the application's responsiveness.

Having a more sophisticated health check pattern (based on Kolme's is the next thing), but this will unblock me currently.