### PR TITLE
feat: include account ID with next nonce

### DIFF
--- a/packages/integration-tests/tests/testapp.rs
+++ b/packages/integration-tests/tests/testapp.rs
@@ -532,7 +532,7 @@ fn wait_for_nonce<'a>(
 ) -> futures::future::BoxFuture<'a, ()> {
     Box::pin(async move {
         loop {
-            let account_nonce = kolme.read().get_next_nonce(secret.public_key());
+            let account_nonce = kolme.read().get_next_nonce(secret.public_key()).1;
             if account_nonce > nonce {
                 tracing::debug!("Got {} new account nonce", account_nonce);
                 return;
@@ -635,7 +635,7 @@ async fn test_concurrent_transactions_inner(
         let kolme_clone = kolme.clone();
 
         let task = tokio::spawn(async move {
-            let next_nonce = kolme_clone.read().get_next_nonce(secret.public_key());
+            let next_nonce = kolme_clone.read().get_next_nonce(secret.public_key()).1;
 
             let tx = Transaction {
                 pubkey: secret.public_key(),

--- a/packages/kolme/src/api_server.rs
+++ b/packages/kolme/src/api_server.rs
@@ -129,8 +129,8 @@ async fn get_next_nonce<App: KolmeApp>(
     State(kolme): State<Kolme<App>>,
     Query(NextNonce { pubkey }): Query<NextNonce>,
 ) -> impl IntoResponse {
-    let nonce = kolme.read().get_next_nonce(pubkey);
-    Json(serde_json::json!({"next_nonce":nonce})).into_response()
+    let (account_id, nonce) = kolme.read().get_next_nonce(pubkey);
+    Json(serde_json::json!({"next_nonce":nonce, "account_id":account_id})).into_response()
 }
 
 async fn get_block<App: KolmeApp>(


### PR DESCRIPTION
In the case of a new account, we return `None` instead of the next account ID, since the actual returned account ID will depend on potential intervening transactions creating other accounts.