### PR TITLE
feat: Add subcommand to print public key

### DIFF
--- a/packages/kolme-cli/justfile
+++ b/packages/kolme-cli/justfile
@@ -1,0 +1,9 @@
+set fallback := true
+
+# List all recipes
+default:
+    just --list --unsorted
+
+# Show public key
+public:
+    cargo run -- pub-key

--- a/packages/kolme-cli/src/main.rs
+++ b/packages/kolme-cli/src/main.rs
@@ -15,6 +15,11 @@ async fn main() -> Result<()> {
 enum Cmd {
     /// Generate a new keypair.
     GenKeypair {},
+    /// Print public key
+    PubKey {
+        #[clap(long, env = "KOLME_CLI_SECRET_KEY")]
+        secret: SecretKey
+    },
     /// Send a transaction via an API server.
     SendTx(SendTxOpt),
     /// Kolme Hub functionality
@@ -40,6 +45,10 @@ async fn main_inner() -> Result<()> {
         Cmd::GenKeypair {} => gen_keypair(),
         Cmd::SendTx(opt) => send_tx(opt).await?,
         Cmd::Hub(cmd) => hub::run(cmd).await?,
+        Cmd::PubKey { secret } => {
+            let public = secret.public_key();
+            eprintln!("Public key: {public}");
+        }
     }
     Ok(())
 }

--- a/packages/kolme-cli/src/main.rs
+++ b/packages/kolme-cli/src/main.rs
@@ -18,7 +18,7 @@ enum Cmd {
     /// Print public key
     PubKey {
         #[clap(long, env = "KOLME_CLI_SECRET_KEY")]
-        secret: SecretKey
+        secret: SecretKey,
     },
     /// Send a transaction via an API server.
     SendTx(SendTxOpt),


### PR DESCRIPTION
This commit introduces a new `pub-key` subcommand to the `kolme-cli` tool. This command allows users to input a secret key (either via a command-line argument or an environment variable) and then prints the corresponding public key to standard error.