### PR TITLE
fix: wait for a transaction locally before considering it landed

### DIFF
--- a/packages/kolme/src/core/kolme.rs
+++ b/packages/kolme/src/core/kolme.rs
@@ -233,6 +233,7 @@ impl<App: KolmeApp> Kolme<App> {
             match note {
                 Notification::NewBlock(block) => {
                     if block.tx().hash() == txhash_orig {
+                        self.wait_for_block(block.height()).await?;
                         break Ok(block);
                     }
                 }


### PR DESCRIPTION
Discovered in code review with @jeffhappily. Before this change, we would consider a transaction as landed even if we hadn't stored the block with the transaction locally. This change forces the block to be stored locally first. This improves the "invalid nonce" errors significantly, and likely fixes other latent bugs in applications that were assuming the local block state included the block in question.