### PR TITLE
Creates a new subscription when websocket fails

### DIFF
--- a/packages/kolme/src/gossip/websockets.rs
+++ b/packages/kolme/src/gossip/websockets.rs
@@ -82,7 +82,7 @@ impl<App: KolmeApp> WebsocketsManager<App> {
         for server in websockets_servers {
             set.spawn(launch_client(
                 local_display_name.clone(),
-                tx_gossip.subscribe(),
+                tx_gossip.clone(),
                 tx_message.clone(),
                 server,
             ));
@@ -103,11 +103,12 @@ impl<App: KolmeApp> WebsocketsManager<App> {
 
 async fn launch_client<App: KolmeApp>(
     local_display_name: Arc<str>,
-    mut rx_gossip: Receiver<GossipMessage<App>>,
+    tx_gossip: Sender<GossipMessage<App>>,
     mut tx_message: tokio::sync::mpsc::Sender<WebsocketsMessage<App>>,
     server: String,
 ) {
     loop {
+        let mut rx_gossip = tx_gossip.subscribe();
         match launch_client_inner(
             local_display_name.clone(),
             &mut rx_gossip,


### PR DESCRIPTION
Websocket connections were not getting restarted after receiving errors such as :

Gossip WebSockets: received error from rx_gossip: channel lagged by 2 local_display_name=gossip

This patch make sure websocket connections are renewed properly to recover from such errors by calling subscribe into the retry  loop.

