### PR TITLE
Kolme feature flags

### DIFF
--- a/packages/examples/cosmos-bridge/Cargo.toml
+++ b/packages/examples/cosmos-bridge/Cargo.toml
@@ -8,7 +8,7 @@ anyhow = { workspace = true }
 clap = { workspace = true }
 cosmos = { workspace = true }
 jiff = { workspace = true }
-kolme = { workspace = true }
+kolme = { workspace = true, features = ["cosmwasm"] }
 rand = { workspace = true }
 reqwest = { workspace = true, features = ["json"] }
 serde = { workspace = true, features = ["derive"] }

--- a/packages/examples/six-sigma/src/lib.rs
+++ b/packages/examples/six-sigma/src/lib.rs
@@ -572,8 +572,7 @@ mod tests {
     use backon::{ExponentialBuilder, Retryable};
     use cosmos::{AddressHrp, HasAddress};
     use futures_util::StreamExt;
-    use pass_through::{MsgResponse, PassThrough};
-    use shared::cosmos::ExecuteMsg;
+    use pass_through::{ExecuteMsg, MsgResponse, PassThrough};
     use tempfile::NamedTempFile;
     use tokio::time::{Duration, Instant};
     use tokio_tungstenite::{connect_async, MaybeTlsStream, WebSocketStream};
@@ -861,7 +860,7 @@ mod tests {
             .post("http://localhost:12345/msg")
             .json(&kolme::pass_through::Msg {
                 wallet,
-                coins: vec![std_coin(to_send)],
+                coins: vec![asset_amount(to_send)],
                 msg: ExecuteMsg::Regular {
                     keys: vec![registration],
                 },
@@ -893,9 +892,9 @@ mod tests {
         Ok(())
     }
 
-    fn std_coin(amount: Decimal) -> cosmwasm_std::Coin {
-        cosmwasm_std::Coin {
-            amount: cosmwasm_std::Uint128::new(u128::try_from(amount * dec!(1_000_000)).unwrap()),
+    fn asset_amount(amount: Decimal) -> BridgedAssetAmount {
+        BridgedAssetAmount {
+            amount: u128::try_from(amount * dec!(1_000_000)).unwrap(),
             denom: "uosmo".to_string(),
         }
     }

--- a/packages/examples/solana-cosmos-bridge/Cargo.toml
+++ b/packages/examples/solana-cosmos-bridge/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 anyhow = { workspace = true }
 cosmos = { workspace = true }
 jiff = { workspace = true }
-kolme = { workspace = true }
+kolme = { workspace = true, features = ["solana", "cosmwasm"] }
 reqwest = { workspace = true, features = ["json"] }
 serde = { workspace = true, features = ["derive"] }
 solana-keypair = { workspace = true }

--- a/packages/integration-tests/Cargo.toml
+++ b/packages/integration-tests/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT"
 [dependencies]
 anyhow = { workspace = true }
 cosmos = { workspace = true }
-kolme = { workspace = true, features = ["pass_through"] }
+kolme = { workspace = true, features = ["cosmwasm", "solana", "pass_through"] }
 kolme-solana-bridge-client = { workspace = true }
 reqwest = { workspace = true, features = ["json"] }
 rust_decimal = { workspace = true }

--- a/packages/kolme/Cargo.toml
+++ b/packages/kolme/Cargo.toml
@@ -11,12 +11,9 @@ anyhow = { workspace = true }
 axum = { workspace = true, features = ["ws"] }
 base64 = { workspace = true }
 borsh = { workspace = true }
-cosmos = { workspace = true, features = ["config"] }
-cosmwasm-std = { workspace = true }
 futures-util = { workspace = true }
 hex.workspace = true
 jiff = { workspace = true }
-kolme-solana-bridge-client = { workspace = true }
 kolme-store.workspace = true
 libp2p = { workspace = true, features = [
   "autonat",
@@ -54,12 +51,8 @@ reqwest = { workspace = true, features = [
 rust_decimal = { workspace = true, features = ["macros"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
-shared = { workspace = true, features = ["cosmwasm", "realcryptography"] }
+shared = { workspace = true, features = ["realcryptography"] }
 smallvec = { workspace = true }
-solana-client = { workspace = true }
-solana-commitment-config = { workspace = true }
-solana-signature = { workspace = true }
-solana-transaction-status-client-types = { workspace = true }
 strum = { workspace = true, features = ["derive"] }
 thiserror = { workspace = true }
 tokio = { workspace = true }
@@ -67,6 +60,17 @@ tokio-tungstenite = { workspace = true }
 tower-http = { workspace = true, features = ["cors"] }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
+
+# Solana
+kolme-solana-bridge-client = { workspace = true, optional = true }
+solana-client = { workspace = true, optional = true }
+solana-commitment-config = { workspace = true, optional = true }
+solana-signature = { workspace = true, optional = true }
+solana-transaction-status-client-types = { workspace = true, optional = true }
+
+# CosmWasm
+cosmos = { workspace = true, features = ["config"], optional = true }
+cosmwasm-std = { workspace = true, optional = true }
 
 [dev-dependencies]
 kademlia-discovery = { workspace = true }
@@ -77,6 +81,12 @@ tempfile = { workspace = true }
 
 [features]
 pass_through = []
+cosmwasm = ["dep:cosmos", "dep:cosmwasm-std", "shared/cosmwasm"]
+solana = [
+  "dep:solana-client", "dep:solana-commitment-config", "dep:solana-signature",
+  "dep:solana-transaction-status-client-types", "dep:kolme-solana-bridge-client",
+  "shared/solana"
+]
 
 [lints]
 workspace = true

--- a/packages/kolme/src/core/kolme.rs
+++ b/packages/kolme/src/core/kolme.rs
@@ -7,11 +7,14 @@ use block_info::BlockState;
 pub(super) use block_info::{BlockInfo, MaybeBlockInfo};
 use kolme_store::{KolmeConstructLock, KolmeStoreError, StorableBlock};
 use parking_lot::RwLock;
+#[cfg(feature = "solana")]
 use solana_client::nonblocking::pubsub_client::PubsubClient;
 pub use store::KolmeStore;
 use utils::trigger::TriggerSubscriber;
 
-use std::{collections::HashMap, ops::Deref, sync::OnceLock, time::Duration};
+#[cfg(any(feature = "solana", feature = "cosmwasm"))]
+use std::collections::HashMap;
+use std::{ops::Deref, sync::OnceLock, time::Duration};
 
 use mempool::Mempool;
 use tokio::sync::broadcast::error::RecvError;
@@ -42,8 +45,11 @@ pub(super) struct KolmeInner<App: KolmeApp> {
     mempool: Mempool<App::Message>,
     pub(super) store: store::KolmeStore<App>,
     pub(super) app: App,
+    #[cfg(feature = "cosmwasm")]
     pub(super) cosmos_conns: tokio::sync::RwLock<HashMap<CosmosChain, cosmos::Cosmos>>,
+    #[cfg(feature = "solana")]
     pub(super) solana_conns: tokio::sync::RwLock<HashMap<SolanaChain, Arc<SolanaClient>>>,
+    #[cfg(feature = "solana")]
     pub(super) solana_endpoints: parking_lot::RwLock<SolanaEndpoints>,
     #[cfg(feature = "pass_through")]
     pub(super) pass_through_conn: OnceLock<reqwest::Client>,
@@ -660,7 +666,9 @@ impl<App: KolmeApp> Kolme<App> {
         let inner = KolmeInner {
             store,
             app,
+            #[cfg(feature = "cosmwasm")]
             cosmos_conns: tokio::sync::RwLock::new(HashMap::new()),
+            #[cfg(feature = "solana")]
             solana_conns: tokio::sync::RwLock::new(HashMap::new()),
             #[cfg(feature = "pass_through")]
             pass_through_conn: OnceLock::new(),
@@ -669,6 +677,7 @@ impl<App: KolmeApp> Kolme<App> {
             // Default value chosen to exceed the libp2p default of 60 seconds
             mempool: Mempool::new(Duration::from_secs(90)),
             current_block: RwLock::new(Arc::new(current_block)),
+            #[cfg(feature = "solana")]
             solana_endpoints: parking_lot::RwLock::new(SolanaEndpoints::default()),
             latest_block: parking_lot::RwLock::new(None),
             code_version: code_version.into(),
@@ -941,6 +950,7 @@ impl<App: KolmeApp> Kolme<App> {
         self.get_merkle_by_hash(hash).await
     }
 
+    #[cfg(feature = "cosmwasm")]
     pub async fn get_cosmos(&self, chain: CosmosChain) -> Result<cosmos::Cosmos> {
         if let Some(cosmos) = self.inner.cosmos_conns.read().await.get(&chain) {
             return Ok(cosmos.clone());
@@ -966,6 +976,7 @@ impl<App: KolmeApp> Kolme<App> {
     /// # Usage
     /// Call this method to specify a custom Solana endpoint for regular connections.
     /// If no custom endpoint is set, a default endpoint will be used.
+    #[cfg(feature = "solana")]
     pub fn set_solana_endpoint_regular(&self, chain: SolanaChain, endpoint: impl Into<Arc<str>>) {
         self.inner
             .solana_endpoints
@@ -975,6 +986,7 @@ impl<App: KolmeApp> Kolme<App> {
     }
 
     /// Set a Solana endpoint for pubsub connections.
+    #[cfg(feature = "solana")]
     pub fn set_solana_endpoint_pubsub(&self, chain: SolanaChain, endpoint: impl Into<Arc<str>>) {
         self.inner
             .solana_endpoints
@@ -983,6 +995,7 @@ impl<App: KolmeApp> Kolme<App> {
             .insert(chain, endpoint.into());
     }
 
+    #[cfg(feature = "solana")]
     pub async fn get_solana_client(&self, chain: SolanaChain) -> Arc<SolanaClient> {
         if let Some(client) = self.inner.solana_conns.read().await.get(&chain) {
             return client.clone();
@@ -1006,6 +1019,7 @@ impl<App: KolmeApp> Kolme<App> {
         }
     }
 
+    #[cfg(feature = "solana")]
     pub async fn get_solana_pubsub_client(&self, chain: SolanaChain) -> Result<PubsubClient> {
         // TODO do we need caching here?
 

--- a/packages/kolme/src/core/types.rs
+++ b/packages/kolme/src/core/types.rs
@@ -2,18 +2,28 @@ mod accounts;
 mod error;
 
 use crate::core::CoreStateError;
-use std::{collections::HashMap, fmt::Display, str::FromStr, sync::OnceLock};
+use std::{fmt::Display, str::FromStr, sync::OnceLock};
 
-use base64::Engine;
-use cosmwasm_std::{Binary, CosmosMsg, Uint128};
 use kolme_store::{BlockHashes, HasBlockHashes};
+
+#[cfg(feature = "cosmwasm")]
+use cosmwasm_std::{Binary, CosmosMsg, Uint128};
+
+#[cfg(feature = "solana")]
+use {
+    base64::Engine,
+    kolme_solana_bridge_client::{pubkey::Pubkey as SolanaPubkey, TokenProgram},
+    std::collections::HashMap,
+};
 
 use crate::*;
 
 pub use accounts::{Account, Accounts, AccountsError};
 pub use error::KolmeError;
 
+#[cfg(feature = "solana")]
 pub type SolanaClient = solana_client::nonblocking::rpc_client::RpcClient;
+#[cfg(feature = "solana")]
 pub type SolanaPubsubClient = solana_client::nonblocking::pubsub_client::PubsubClient;
 
 #[derive(
@@ -101,6 +111,7 @@ pub enum CosmosChain {
 }
 
 #[derive(PartialEq, Clone, Copy, Debug)]
+#[non_exhaustive]
 pub enum ChainName {
     Cosmos,
     Solana,
@@ -109,6 +120,7 @@ pub enum ChainName {
 }
 
 #[derive(PartialEq, Clone, Copy, Debug)]
+#[non_exhaustive]
 pub enum ChainKind {
     Cosmos(CosmosChain),
     Solana(SolanaChain),
@@ -121,6 +133,7 @@ impl CosmosChain {
         ChainName::Cosmos
     }
 
+    #[cfg(feature = "cosmwasm")]
     pub async fn make_client(self) -> Result<cosmos::Cosmos> {
         let network = match self {
             Self::OsmosisTestnet => cosmos::CosmosNetwork::OsmosisTestnet,
@@ -132,17 +145,20 @@ impl CosmosChain {
     }
 }
 
+#[cfg(feature = "solana")]
 #[derive(Default)]
 pub struct SolanaEndpoints {
     pub regular: HashMap<SolanaChain, Arc<str>>,
     pub pubsub: HashMap<SolanaChain, Arc<str>>,
 }
 
+#[cfg(feature = "solana")]
 pub enum SolanaClientEndpoint {
     Static(&'static str),
     Arc(Arc<str>),
 }
 
+#[cfg(feature = "solana")]
 impl SolanaEndpoints {
     pub fn get_regular_endpoint(&self, chain: SolanaChain) -> SolanaClientEndpoint {
         self.regular.get(&chain).map_or(
@@ -169,6 +185,7 @@ impl SolanaEndpoints {
     }
 }
 
+#[cfg(feature = "solana")]
 impl SolanaClientEndpoint {
     pub fn make_client(self) -> SolanaClient {
         SolanaClient::new(match self {
@@ -1387,6 +1404,7 @@ impl ChainStates {
 pub struct ConfiguredChains(pub(crate) BTreeMap<ExternalChain, ChainConfig>);
 
 impl ConfiguredChains {
+    #[cfg(feature = "solana")]
     pub fn insert_solana(&mut self, chain: SolanaChain, config: ChainConfig) -> Result<()> {
         use kolme_solana_bridge_client::pubkey::Pubkey;
 
@@ -1405,6 +1423,7 @@ impl ConfiguredChains {
         Ok(())
     }
 
+    #[cfg(feature = "cosmwasm")]
     pub fn insert_cosmos(&mut self, chain: CosmosChain, config: ChainConfig) -> Result<()> {
         use cosmos::Address;
 
@@ -1480,14 +1499,17 @@ pub enum ExecAction {
 impl ExecAction {
     /// - Cosmos chains: returns a JSON string of a BridgeActionId and Vec<cosmwasm_std::CosmosMsg>
     /// - Solana chains: returns a base64 encoded string of a borsh serialized kolme_solana_bridge_client::Payload binary
+    #[allow(unused)]
     pub(crate) fn to_payload(
         &self,
         chain: ExternalChain,
         config: &ChainConfig,
         id: BridgeActionId,
     ) -> Result<String> {
-        use kolme_solana_bridge_client::{pubkey::Pubkey as SolanaPubkey, TokenProgram};
-        use shared::{cosmos, solana};
+        #[cfg(feature = "cosmwasm")]
+        use shared::cosmos;
+        #[cfg(feature = "solana")]
+        use shared::solana;
 
         match self {
             Self::Transfer {
@@ -1498,6 +1520,7 @@ impl ExecAction {
                 assert_eq!(&chain, chain2);
 
                 match chain.name() {
+                    #[cfg(feature = "cosmwasm")]
                     ChainName::Cosmos => {
                         let mut coins = vec![];
                         for AssetAmount { id, amount } in funds {
@@ -1527,6 +1550,9 @@ impl ExecAction {
 
                         Ok(payload)
                     }
+                    #[cfg(not(feature = "cosmwasm"))]
+                    ChainName::Cosmos => unreachable!(),
+                    #[cfg(feature = "solana")]
                     ChainName::Solana => {
                         let mut coins: Vec<(&str, u128)> = Vec::with_capacity(funds.len());
                         for coin in funds {
@@ -1563,6 +1589,8 @@ impl ExecAction {
 
                         serialize_solana_payload(&payload)
                     }
+                    #[cfg(not(feature = "solana"))]
+                    ChainName::Solana => unreachable!(),
                     #[cfg(feature = "pass_through")]
                     ChainName::PassThrough => {
                         let payload = serde_json::to_string(&pass_through::Transfer {
@@ -1575,6 +1603,7 @@ impl ExecAction {
                 }
             }
             ExecAction::SelfReplace(self_replace) => match chain.name() {
+                #[cfg(feature = "cosmwasm")]
                 ChainName::Cosmos => {
                     let payload = serde_json::to_string(&cosmos::PayloadWithId {
                         id,
@@ -1589,6 +1618,9 @@ impl ExecAction {
 
                     Ok(payload)
                 }
+                #[cfg(not(feature = "cosmwasm"))]
+                ChainName::Cosmos => unreachable!(),
+                #[cfg(feature = "solana")]
                 ChainName::Solana => {
                     let payload = solana::Payload {
                         id: id.0,
@@ -1603,6 +1635,8 @@ impl ExecAction {
 
                     serialize_solana_payload(&payload)
                 }
+                #[cfg(not(feature = "solana"))]
+                ChainName::Solana => unreachable!(),
                 #[cfg(feature = "pass_through")]
                 ChainName::PassThrough => todo!(),
             },
@@ -1610,6 +1644,7 @@ impl ExecAction {
                 validator_set,
                 approvals,
             } => match chain.name() {
+                #[cfg(feature = "cosmwasm")]
                 ChainName::Cosmos => {
                     let payload = serde_json::to_string(&cosmos::PayloadWithId {
                         id,
@@ -1621,6 +1656,9 @@ impl ExecAction {
 
                     Ok(payload)
                 }
+                #[cfg(not(feature = "cosmwasm"))]
+                ChainName::Cosmos => unreachable!(),
+                #[cfg(feature = "solana")]
                 ChainName::Solana => {
                     let payload = solana::Payload {
                         id: id.0,
@@ -1632,11 +1670,14 @@ impl ExecAction {
 
                     serialize_solana_payload(&payload)
                 }
+                #[cfg(not(feature = "solana"))]
+                ChainName::Solana => unreachable!(),
                 #[cfg(feature = "pass_through")]
                 ChainName::PassThrough => todo!(),
             },
             ExecAction::MigrateContract { migrate_contract } => {
                 match chain.name() {
+                    #[cfg(feature = "cosmwasm")]
                     ChainName::Cosmos => {
                         let contract_addr = match &config.bridge {
                         BridgeContract::Deployed(addr) => addr.clone(),
@@ -1659,7 +1700,12 @@ impl ExecAction {
 
                         Ok(payload)
                     }
+                    #[cfg(not(feature = "cosmwasm"))]
+                    ChainName::Cosmos => unreachable!(),
+                    #[cfg(feature = "solana")]
                     ChainName::Solana => todo!(),
+                    #[cfg(not(feature = "solana"))]
+                    ChainName::Solana => unreachable!(),
                     #[cfg(feature = "pass_through")]
                     ChainName::PassThrough => todo!(),
                 }
@@ -1668,6 +1714,7 @@ impl ExecAction {
     }
 }
 
+#[cfg(feature = "solana")]
 fn serialize_solana_payload(payload: &shared::solana::Payload) -> Result<String> {
     let len = borsh::object_length(&payload)
         .map_err(|x| anyhow::anyhow!("Error serializing Solana bridge payload: {:?}", x))?;

--- a/packages/kolme/src/core/types.rs
+++ b/packages/kolme/src/core/types.rs
@@ -111,7 +111,6 @@ pub enum CosmosChain {
 }
 
 #[derive(PartialEq, Clone, Copy, Debug)]
-#[non_exhaustive]
 pub enum ChainName {
     Cosmos,
     Solana,
@@ -120,7 +119,6 @@ pub enum ChainName {
 }
 
 #[derive(PartialEq, Clone, Copy, Debug)]
-#[non_exhaustive]
 pub enum ChainKind {
     Cosmos(CosmosChain),
     Solana(SolanaChain),

--- a/packages/kolme/src/lib.rs
+++ b/packages/kolme/src/lib.rs
@@ -3,10 +3,12 @@ mod approver;
 mod common;
 mod core;
 pub mod gossip;
+#[cfg(any(feature = "solana", feature = "cosmwasm", feature = "pass_through"))]
 pub(crate) mod listener;
 #[cfg(feature = "pass_through")]
 pub mod pass_through;
 mod processor;
+#[cfg(any(feature = "solana", feature = "cosmwasm", feature = "pass_through"))]
 mod submitter;
 pub mod testtasks;
 mod upgrader;
@@ -18,12 +20,14 @@ pub use common::*;
 pub use core::*;
 pub use gossip::{Gossip, GossipBuilder, SyncMode};
 pub use jiff::Timestamp;
+#[cfg(any(feature = "solana", feature = "cosmwasm", feature = "pass_through"))]
 pub use listener::Listener;
 pub use merkle_map::*;
 pub use processor::Processor;
 pub use rust_decimal::Decimal;
 pub use shared::debug::*;
 pub use shared::{cryptography::*, types::*};
+#[cfg(any(feature = "solana", feature = "cosmwasm", feature = "pass_through"))]
 pub use submitter::Submitter;
 pub use upgrader::Upgrader;
 

--- a/packages/kolme/src/listener/cosmos.rs
+++ b/packages/kolme/src/listener/cosmos.rs
@@ -100,7 +100,7 @@ pub async fn sanity_check_contract(
     Ok(())
 }
 
-pub(crate) fn to_kolme_message<T>(
+fn to_kolme_message<T>(
     msg: BridgeEventMessage,
     chain: ExternalChain,
     event_id: BridgeEventId,

--- a/packages/kolme/src/submitter/mod.rs
+++ b/packages/kolme/src/submitter/mod.rs
@@ -1,8 +1,11 @@
+#[cfg(feature = "cosmwasm")]
 mod cosmos;
+#[cfg(feature = "solana")]
 mod solana;
 
-use crate::*;
 use std::collections::{HashMap, HashSet};
+
+use crate::*;
 
 /// Component which submits necessary transactions to the blockchain.
 pub struct Submitter<App: KolmeApp> {
@@ -16,29 +19,30 @@ pub struct Submitter<App: KolmeApp> {
     /// because our new contract will only be recognized in a later transaction.
     ///
     /// Simple solution: only instantiate once per chain.
+    #[allow(dead_code)] // Unused when only the "pass_through" feature is enabled.
     genesis_created: HashSet<ExternalChain>,
     last_submitted: HashMap<ExternalChain, BridgeActionId>,
 }
 
 enum ChainArgs {
-    Cosmos {
-        seed_phrase: ::cosmos::SeedPhrase,
-    },
+    #[cfg(feature = "cosmwasm")]
+    Cosmos { seed_phrase: ::cosmos::SeedPhrase },
+    #[cfg(feature = "solana")]
     Solana {
         keypair: kolme_solana_bridge_client::keypair::Keypair,
         fee_per_cu: Option<u64>,
     },
     #[cfg(feature = "pass_through")]
-    PassThrough {
-        port: u16,
-    },
+    PassThrough { port: u16 },
 }
 
 impl ChainArgs {
     #[inline]
     fn can_handle(&self, chain: ExternalChain) -> bool {
         match self {
+            #[cfg(feature = "cosmwasm")]
             Self::Cosmos { .. } => chain.to_cosmos_chain().is_some(),
+            #[cfg(feature = "solana")]
             Self::Solana { .. } => chain.to_solana_chain().is_some(),
             #[cfg(feature = "pass_through")]
             Self::PassThrough { .. } => chain == ExternalChain::PassThrough,
@@ -47,6 +51,7 @@ impl ChainArgs {
 }
 
 impl<App: KolmeApp> Submitter<App> {
+    #[cfg(feature = "cosmwasm")]
     pub fn new_cosmos(kolme: Kolme<App>, seed_phrase: ::cosmos::SeedPhrase) -> Self {
         Submitter {
             kolme,
@@ -56,6 +61,7 @@ impl<App: KolmeApp> Submitter<App> {
         }
     }
 
+    #[cfg(feature = "solana")]
     pub fn new_solana(
         kolme: Kolme<App>,
         keypair: kolme_solana_bridge_client::keypair::Keypair,
@@ -136,13 +142,16 @@ impl<App: KolmeApp> Submitter<App> {
     }
 
     async fn handle_genesis(&mut self, genesis_action: GenesisAction) -> Result<()> {
-        let (contract_addr, chain) = match genesis_action {
+        match genesis_action {
+            #[cfg(feature = "cosmwasm")]
             GenesisAction::InstantiateCosmos {
                 chain,
                 code_id,
                 validator_set: args,
             } => {
-                let ChainArgs::Cosmos { seed_phrase } = &self.args else {
+                #[allow(irrefutable_let_patterns)]
+                let ChainArgs::Cosmos { seed_phrase } = &self.args
+                else {
                     return Ok(());
                 };
 
@@ -151,16 +160,26 @@ impl<App: KolmeApp> Submitter<App> {
                 }
 
                 let cosmos = self.kolme.read().get_cosmos(chain).await?;
-
                 let addr = cosmos::instantiate(&cosmos, seed_phrase, code_id, args).await?;
 
-                (addr, chain.into())
+                self.kolme.notify(Notification::GenesisInstantiation {
+                    chain: chain.into(),
+                    contract: addr,
+                });
+
+                self.genesis_created.insert(chain.into());
+
+                Ok(())
             }
+            #[cfg(not(feature = "cosmwasm"))]
+            GenesisAction::InstantiateCosmos { .. } => Ok(()),
+            #[cfg(feature = "solana")]
             GenesisAction::InstantiateSolana {
                 chain,
                 program_id,
                 validator_set: args,
             } => {
+                #[allow(irrefutable_let_patterns)]
                 let ChainArgs::Solana {
                     keypair,
                     fee_per_cu: _,
@@ -174,20 +193,20 @@ impl<App: KolmeApp> Submitter<App> {
                 }
 
                 let client = self.kolme.read().get_solana_client(chain).await;
-
                 solana::instantiate(&client, keypair, &program_id, args).await?;
 
-                (program_id, chain.into())
+                self.kolme.notify(Notification::GenesisInstantiation {
+                    chain: chain.into(),
+                    contract: program_id,
+                });
+
+                self.genesis_created.insert(chain.into());
+
+                Ok(())
             }
-        };
-
-        self.kolme.notify(Notification::GenesisInstantiation {
-            chain,
-            contract: contract_addr,
-        });
-        self.genesis_created.insert(chain);
-
-        Ok(())
+            #[cfg(not(feature = "solana"))]
+            GenesisAction::InstantiateSolana { .. } => Ok(()),
+        }
     }
 
     async fn handle_bridge_action(
@@ -225,6 +244,7 @@ impl<App: KolmeApp> Submitter<App> {
         tracing::info!("Handling bridge action {action_id} for chain: {chain:?}.");
 
         let tx_hash = match &self.args {
+            #[cfg(feature = "cosmwasm")]
             ChainArgs::Cosmos { seed_phrase } => {
                 let Some(cosmos_chain) = chain.to_cosmos_chain() else {
                     return Ok(());
@@ -242,6 +262,7 @@ impl<App: KolmeApp> Submitter<App> {
                 )
                 .await?
             }
+            #[cfg(feature = "solana")]
             ChainArgs::Solana {
                 keypair,
                 fee_per_cu,
@@ -267,6 +288,9 @@ impl<App: KolmeApp> Submitter<App> {
             ChainArgs::PassThrough { port } => {
                 anyhow::ensure!(chain == ExternalChain::PassThrough);
                 let client = self.kolme.read().get_pass_through_client();
+
+                tracing::info!("Executing pass through contract: {contract}");
+
                 pass_through::execute(client, *port, *processor, approvals, payload).await?
             }
         };

--- a/packages/kolme/src/utils/mod.rs
+++ b/packages/kolme/src/utils/mod.rs
@@ -1,4 +1,5 @@
 //! Various utilities
 
+#[cfg(feature = "cosmwasm")]
 pub mod cosmos;
 pub mod trigger;


### PR DESCRIPTION
- Add feature flags for Cosmos/Solana support.
- Make passthrough bridge independent of CosmWasm types.

At first glance it might seem that feature gating `ExternalChain` and `ChainKind` is the correct approach. However, as I learned the hard way, this introduces a lot of issues with unused code in the core code that are not easily solvable and needing to resort to using `#[cfg(feature = "x")]` a lot more.

Instead, I've feature gated the public APIs and changed the code where these chain-related dependencies are used (which is mainly the submitter and listener).