### PR TITLE
fix: remove the network-ready check in gossip

### DIFF
--- a/packages/kolme-test/src/archiver.rs
+++ b/packages/kolme-test/src/archiver.rs
@@ -48,14 +48,12 @@ async fn archiver_inner(testtasks: TestTasks, (): ()) {
     )
     .await
     .unwrap();
-    testtasks
-        .launch_websockets_client_with(
-            kolme_archiver.clone(),
-            "kolme_archiver",
-            &discovery,
-            |gossip| gossip.set_sync_mode(SyncMode::Archive, DataLoadValidation::ValidateDataLoads),
-        )
-        .await;
+    testtasks.launch_websockets_client_with(
+        kolme_archiver.clone(),
+        "kolme_archiver",
+        &discovery,
+        |gossip| gossip.set_sync_mode(SyncMode::Archive, DataLoadValidation::ValidateDataLoads),
+    );
 
     assert!(latest_block_height.0 > 0);
 

--- a/packages/kolme-test/src/p2p_fast.rs
+++ b/packages/kolme-test/src/p2p_fast.rs
@@ -60,19 +60,17 @@ async fn fast_sync_inner(testtasks: TestTasks, (): ()) {
     )
     .await
     .unwrap();
-    testtasks
-        .launch_websockets_client_with(
-            kolme_block_transfer.clone(),
-            "kolme_block_transfer",
-            &discovery,
-            |gossip| {
-                gossip.set_sync_mode(
-                    SyncMode::BlockTransfer,
-                    DataLoadValidation::ValidateDataLoads,
-                )
-            },
-        )
-        .await;
+    testtasks.launch_websockets_client_with(
+        kolme_block_transfer.clone(),
+        "kolme_block_transfer",
+        &discovery,
+        |gossip| {
+            gossip.set_sync_mode(
+                SyncMode::BlockTransfer,
+                DataLoadValidation::ValidateDataLoads,
+            )
+        },
+    );
 
     // We'll check at the end of the run to confirm that this never received the latest block.
     // First check that StateTransfer works
@@ -83,19 +81,17 @@ async fn fast_sync_inner(testtasks: TestTasks, (): ()) {
     )
     .await
     .unwrap();
-    testtasks
-        .launch_websockets_client_with(
-            kolme_state_transfer.clone(),
-            "kolme_state_transfer",
-            &discovery,
-            |gossip| {
-                gossip.set_sync_mode(
-                    SyncMode::StateTransfer,
-                    DataLoadValidation::ValidateDataLoads,
-                )
-            },
-        )
-        .await;
+    testtasks.launch_websockets_client_with(
+        kolme_state_transfer.clone(),
+        "kolme_state_transfer",
+        &discovery,
+        |gossip| {
+            gossip.set_sync_mode(
+                SyncMode::StateTransfer,
+                DataLoadValidation::ValidateDataLoads,
+            )
+        },
+    );
 
     // We should be able to sync the latest block within a few seconds
     let latest_from_gossip = tokio::time::timeout(

--- a/packages/kolme-test/src/p2p_large.rs
+++ b/packages/kolme-test/src/p2p_large.rs
@@ -176,19 +176,17 @@ async fn large_sync_inner(testtasks: TestTasks, (): ()) {
     )
     .await
     .unwrap();
-    testtasks
-        .launch_websockets_client_with(
-            kolme_state_transfer.clone(),
-            "kolme_state_transfer",
-            &discovery,
-            |builder| {
-                builder.set_sync_mode(
-                    SyncMode::StateTransfer,
-                    DataLoadValidation::ValidateDataLoads,
-                )
-            },
-        )
-        .await;
+    testtasks.launch_websockets_client_with(
+        kolme_state_transfer.clone(),
+        "kolme_state_transfer",
+        &discovery,
+        |builder| {
+            builder.set_sync_mode(
+                SyncMode::StateTransfer,
+                DataLoadValidation::ValidateDataLoads,
+            )
+        },
+    );
 
     let kolme_state_transfer2 = Kolme::new(
         SampleKolmeApp::new(IDENT),
@@ -197,19 +195,17 @@ async fn large_sync_inner(testtasks: TestTasks, (): ()) {
     )
     .await
     .unwrap();
-    testtasks
-        .launch_websockets_client_with(
-            kolme_state_transfer2.clone(),
-            "kolme_state_transfer2",
-            &discovery,
-            |builder| {
-                builder.set_sync_mode(
-                    SyncMode::StateTransfer,
-                    DataLoadValidation::ValidateDataLoads,
-                )
-            },
-        )
-        .await;
+    testtasks.launch_websockets_client_with(
+        kolme_state_transfer2.clone(),
+        "kolme_state_transfer2",
+        &discovery,
+        |builder| {
+            builder.set_sync_mode(
+                SyncMode::StateTransfer,
+                DataLoadValidation::ValidateDataLoads,
+            )
+        },
+    );
 
     // Due to data size, it can take a bit to transfer the entire state
     let latest_from_gossip = tokio::time::timeout(

--- a/packages/kolme-test/src/p2p_sanity.rs
+++ b/packages/kolme-test/src/p2p_sanity.rs
@@ -38,9 +38,7 @@ async fn sanity_inner(testtasks: TestTasks, (): ()) {
     )
     .await
     .unwrap();
-    testtasks
-        .launch_websockets_client(kolme_client.clone(), "sanity-client", &discovery)
-        .await;
+    testtasks.launch_websockets_client(kolme_client.clone(), "sanity-client", &discovery);
 
     let secret = SecretKey::random();
     timeout(

--- a/packages/kolme-test/src/p2p_websockets_sanity.rs
+++ b/packages/kolme-test/src/p2p_websockets_sanity.rs
@@ -38,9 +38,7 @@ async fn ws_sanity_inner(testtasks: TestTasks, (): ()) {
     )
     .await
     .unwrap();
-    testtasks
-        .launch_websockets_client(kolme_client.clone(), "sanity-client", &discovery)
-        .await;
+    testtasks.launch_websockets_client(kolme_client.clone(), "sanity-client", &discovery);
 
     let secret = SecretKey::random();
     timeout(

--- a/packages/kolme-test/src/sync_older.rs
+++ b/packages/kolme-test/src/sync_older.rs
@@ -66,19 +66,17 @@ async fn sync_older_inner(testtasks: TestTasks, (): ()) {
     )
     .await
     .unwrap();
-    testtasks
-        .launch_websockets_client_with(
-            kolme_state_transfer.clone(),
-            "kolme_state_transfer",
-            &discovery,
-            |builder| {
-                builder.set_sync_mode(
-                    SyncMode::StateTransfer,
-                    DataLoadValidation::ValidateDataLoads,
-                )
-            },
-        )
-        .await;
+    testtasks.launch_websockets_client_with(
+        kolme_state_transfer.clone(),
+        "kolme_state_transfer",
+        &discovery,
+        |builder| {
+            builder.set_sync_mode(
+                SyncMode::StateTransfer,
+                DataLoadValidation::ValidateDataLoads,
+            )
+        },
+    );
 
     // We should be able to sync the latest block within a few seconds
     let latest_from_gossip = tokio::time::timeout(

--- a/packages/kolme-test/src/tx_evicted_mempool.rs
+++ b/packages/kolme-test/src/tx_evicted_mempool.rs
@@ -51,11 +51,9 @@ async fn evicts_same_tx_mempool_inner(test_tasks: TestTasks, (): ()) {
     .await
     .unwrap();
     test_tasks.try_spawn(repeat_client(kolme.clone()));
-    test_tasks
-        .launch_websockets_client_with(kolme.clone(), "kolme-client", &discovery, |item| {
-            item.set_duplicate_cache_time(Duration::from_micros(100))
-        })
-        .await;
+    test_tasks.launch_websockets_client_with(kolme.clone(), "kolme-client", &discovery, |item| {
+        item.set_duplicate_cache_time(Duration::from_micros(100))
+    });
 }
 
 async fn repeat_client(kolme: Kolme<SampleKolmeApp>) -> Result<()> {
@@ -129,9 +127,7 @@ async fn tx_evicted_inner(test_tasks: TestTasks, (): ()) {
     .unwrap();
     let mutex = Arc::new(Mutex::new(Vec::new()));
     test_tasks.try_spawn(client(kolme.clone(), sender, mutex.clone()));
-    test_tasks
-        .launch_websockets_client(kolme.clone(), "kolme-client", &discovery)
-        .await;
+    test_tasks.launch_websockets_client(kolme.clone(), "kolme-client", &discovery);
 
     let kolme = Kolme::new(
         SampleKolmeApp::new("Dev code"),
@@ -142,9 +138,7 @@ async fn tx_evicted_inner(test_tasks: TestTasks, (): ()) {
     .unwrap();
     let kolme = kolme.set_tx_await_duration(Duration::from_secs(5));
     test_tasks.try_spawn(no_op_node(kolme.clone(), receiver, mutex));
-    test_tasks
-        .launch_websockets_client(kolme, "kolme-no-op", &discovery)
-        .await;
+    test_tasks.launch_websockets_client(kolme, "kolme-no-op", &discovery);
 }
 
 async fn no_op_node(

--- a/packages/kolme-test/src/upgrade.rs
+++ b/packages/kolme-test/src/upgrade.rs
@@ -153,14 +153,12 @@ async fn test_upgrade_inner(testtasks: TestTasks, (): ()) -> Result<()> {
         .await
         .unwrap();
     testtasks.try_spawn_persistent(Processor::new(kolme2.clone(), processor.clone()).run());
-    testtasks
-        .launch_websockets_client_with(kolme2.clone(), "kolme2", &discovery, |builder| {
-            builder.set_sync_mode(
-                SyncMode::StateTransfer,
-                DataLoadValidation::ValidateDataLoads,
-            )
-        })
-        .await;
+    testtasks.launch_websockets_client_with(kolme2.clone(), "kolme2", &discovery, |builder| {
+        builder.set_sync_mode(
+            SyncMode::StateTransfer,
+            DataLoadValidation::ValidateDataLoads,
+        )
+    });
 
     let client = SecretKey::random();
     const HI_COUNT1: u64 = 10;

--- a/packages/kolme/src/testtasks/kademlia_helper.rs
+++ b/packages/kolme/src/testtasks/kademlia_helper.rs
@@ -38,7 +38,7 @@ impl TestTasks {
         WebsocketsDiscovery { port }
     }
 
-    pub async fn launch_websockets_client<App: KolmeApp>(
+    pub fn launch_websockets_client<App: KolmeApp>(
         &self,
         kolme: Kolme<App>,
         display_name: &str,
@@ -49,11 +49,10 @@ impl TestTasks {
                 SyncMode::BlockTransfer,
                 DataLoadValidation::ValidateDataLoads,
             )
-        })
-        .await;
+        });
     }
 
-    pub async fn launch_websockets_client_with<App: KolmeApp, F>(
+    pub fn launch_websockets_client_with<App: KolmeApp, F>(
         &self,
         kolme: Kolme<App>,
         display_name: &str,
@@ -67,12 +66,7 @@ impl TestTasks {
             .add_websockets_server(format!("ws://127.0.0.1:{}", discovery.port));
         let builder = f(builder);
         let gossip = builder.build(kolme.clone()).unwrap();
-        let mut ready = gossip.subscribe_network_ready();
         self.try_spawn_persistent(gossip.run());
-        tokio::time::timeout(tokio::time::Duration::from_secs(30), ready.changed())
-            .await
-            .expect("Timed out waiting for network to be ready")
-            .unwrap();
     }
 }
 


### PR DESCRIPTION
This always had dubious benefit and vague definitions. Better to simply remove it entirely, and instead provide more direct queries like "what is the latest block height we know that the processor produced?" Those changes are coming in future notification-overhauling PRs.