### PR TITLE
fix: broadcast every landed transaction

### DIFF
--- a/packages/kolme/src/core/kolme/mempool.rs
+++ b/packages/kolme/src/core/kolme/mempool.rs
@@ -93,15 +93,18 @@ impl<AppMessage> Mempool<AppMessage> {
     }
 
     /// Mark a transaction as blocked by already being in the chain.
-    pub(super) fn add_signed_block(&self, block: Arc<SignedBlock<AppMessage>>) {
+    ///
+    /// Returns [true] if this is a newly added block.
+    pub(super) fn add_signed_block(&self, block: Arc<SignedBlock<AppMessage>>) -> bool {
         let mut guard = self.state.write();
         let hash = block.tx().hash();
         if guard.blocked.contains(&hash) {
-            return;
+            return false;
         }
         guard.blocked.put(hash, BlockReason::InBlock(block));
         guard.drop_tx(hash, &self.notify);
         self.notify.trigger();
+        true
     }
 
     /// Mark a transaction as failed.

--- a/packages/kolme/src/gossip/messages.rs
+++ b/packages/kolme/src/gossip/messages.rs
@@ -36,6 +36,10 @@ pub(super) enum GossipMessage<App: KolmeApp> {
     FailedTransaction {
         failed: Arc<SignedTaggedJson<FailedTransaction>>,
     },
+    /// Notification from the processor that a transaction has landed.
+    LandedTransaction {
+        block: Arc<SignedBlock<App::Message>>,
+    },
 }
 
 impl<App: KolmeApp> Display for GossipMessage<App> {
@@ -62,6 +66,12 @@ impl<App: KolmeApp> Display for GossipMessage<App> {
                     failed.message.as_inner()
                 )
             }
+            GossipMessage::LandedTransaction { block } => write!(
+                f,
+                "Report landed transaction {} in {}",
+                block.tx().hash(),
+                block.height()
+            ),
         }
     }
 }


### PR DESCRIPTION
This ensures that if a node is waiting for a transaction, but is using state sync and doesn't add every block to its store, we'll still be able to notify that the transaction landed.