### PR TITLE
feat: Enhance block API

### DIFF
--- a/packages/examples/kademlia-discovery/justfile
+++ b/packages/examples/kademlia-discovery/justfile
@@ -18,11 +18,11 @@ node-v2:
 
 # Run client
 client:
-    cargo run -- client --validator /ip4/127.0.0.1/tcp/2001 --continous
+    cargo run -- client --validator ws://127.0.0.1:2001 --continous
 
 # Run client with v2
 client-v2:
-    cargo run -- new-version-client --validator /ip4/127.0.0.1/tcp/3003 --continous
+    cargo run -- new-version-client --validator 127.0.0.1:2001 --continous
 
 # Run observer node
 observer:

--- a/packages/examples/kademlia-discovery/src/lib.rs
+++ b/packages/examples/kademlia-discovery/src/lib.rs
@@ -234,6 +234,7 @@ pub async fn new_version_node(api_server_port: u16) -> Result<()> {
 
     let gossip = GossipBuilder::new()
         .set_duplicate_cache_time(Duration::from_secs(1))
+        .add_websockets_server("ws://127.0.0.1:2006")
         .build(kolme.clone())?;
     set.spawn(gossip.run());
 

--- a/packages/examples/kademlia-discovery/src/main.rs
+++ b/packages/examples/kademlia-discovery/src/main.rs
@@ -84,8 +84,8 @@ async fn main_inner() -> Result<()> {
             use_fjall_storage,
         } => validators(port, enable_api_server, start_upgrade, use_fjall_storage).await,
         Cmd::Client {
-            validator,
             continous,
+            validator,
         } => client(&validator, SecretKey::random(), continous).await,
         Cmd::Observer {
             validator,

--- a/packages/kolme/src/core/kolme.rs
+++ b/packages/kolme/src/core/kolme.rs
@@ -1110,6 +1110,11 @@ impl<App: KolmeApp> Kolme<App> {
         self.inner.store.load_block(height).await
     }
 
+    pub async fn get_framework(&self, hash: Sha256Hash) -> Result<FrameworkState> {
+        let result = self.inner.store.load(hash).await?;
+        Ok(result)
+    }
+
     /// Check if the given block is available in storage.
     pub async fn has_block(&self, height: BlockHeight) -> Result<bool, KolmeStoreError> {
         self.inner.store.has_block(height).await


### PR DESCRIPTION
This commit introduces improvements to the node's API by exposing more information about chain version. The idea is to build `kolme-cli` on top of this information.

Additionally, fixes the kademlia examples for websockets.