### PR TITLE
Ethereum: ERC20 support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,3 +2,6 @@
 	path = contracts/ethereum/lib/forge-std
 	url = https://github.com/foundry-rs/forge-std
 
+[submodule "contracts/ethereum/lib/openzeppelin-contracts"]
+	path = contracts/ethereum/lib/openzeppelin-contracts
+	url = https://github.com/OpenZeppelin/openzeppelin-contracts

--- a/contracts/ethereum/e2e/README.md
+++ b/contracts/ethereum/e2e/README.md
@@ -38,15 +38,21 @@ cast code <bridge_contract_address> --rpc-url http://localhost:8545
 - Configure Kolme's Ethereum RPC client to point at `http://host.docker.internal:8545` when Kolme itself runs in Docker.
 - Use `http://localhost:8545` when Kolme runs directly on the host.
 
-## ERC20 Deposit Flow
+## Deposit Flow
 
-For ERC20 deposits, user flow is:
+Deposits are submitted via `regular(tokens, amounts, keys)`.
+
+### ERC20
 
 1. Call `approve(<bridge_address>, <amount>)` on the token contract.
-2. Call `regular(<token_address>, <amount>, <keys>)` on the bridge contract.
+2. Call `regular([<token_address>], [<amount>], <keys>)` on the bridge contract with `msg.value = 0`.
+
+### ETH
+
+1. Call `regular([address(0)], [<amount_wei>], <keys>)` on the bridge contract with `msg.value = <amount_wei>`.
 
 Notes:
-- `regular(...)` rejects `token = address(0)`. Native ETH deposits use plain ETH transfer to bridge (`receive()` path), not `regular(...)`.
+- Plain ETH transfers to the bridge are unsupported and revert.
 - `keys` are user secp256k1 pubkeys provided with the deposit event payload.
 
 ## Ethereum Denom Format (Kolme side)

--- a/contracts/ethereum/e2e/README.md
+++ b/contracts/ethereum/e2e/README.md
@@ -49,10 +49,11 @@ Deposits are submitted via `regular(tokens, amounts, keys)`.
 
 ### ETH
 
-1. Call `regular([address(0)], [<amount_wei>], <keys>)` on the bridge contract with `msg.value = <amount_wei>`.
+1. Call `regular([], [], <keys>)` on the bridge contract with `msg.value = <amount_wei>`.
 
 Notes:
 - Plain ETH transfers to the bridge are unsupported and revert.
+- `regular(...)` input funds in calldata are ERC20-only; `token = address(0)` in `tokens` is rejected, ETH is in `msg.value`
 - `keys` are user secp256k1 pubkeys provided with the deposit event payload.
 
 ## Ethereum Denom Format (Kolme side)

--- a/contracts/ethereum/e2e/README.md
+++ b/contracts/ethereum/e2e/README.md
@@ -38,6 +38,22 @@ cast code <bridge_contract_address> --rpc-url http://localhost:8545
 - Configure Kolme's Ethereum RPC client to point at `http://host.docker.internal:8545` when Kolme itself runs in Docker.
 - Use `http://localhost:8545` when Kolme runs directly on the host.
 
+## ERC20 Deposit Flow
+
+For ERC20 deposits, user flow is:
+
+1. Call `approve(<bridge_address>, <amount>)` on the token contract.
+2. Call `regular(<token_address>, <amount>, <keys>)` on the bridge contract.
+
+Notes:
+- `regular(...)` rejects `token = address(0)`. Native ETH deposits use plain ETH transfer to bridge (`receive()` path), not `regular(...)`.
+- `keys` are user secp256k1 pubkeys provided with the deposit event payload.
+
+## Ethereum Denom Format (Kolme side)
+
+- Native ETH denom: `eth` (lowercase).
+- ERC20 denom: canonical lowercase EVM address (`0x...`).
+
 ## Relevant Identifiers
 
 The values below are valid for this setup only when using this mnemonic:

--- a/contracts/ethereum/e2e/bridge/Dockerfile
+++ b/contracts/ethereum/e2e/bridge/Dockerfile
@@ -1,4 +1,6 @@
-FROM ubuntu:24.04 AS foundry
+FROM ubuntu:24.04@sha256:0d39fcc8335d6d74d5502f6df2d30119ff4790ebbb60b364818d5112d9e3e932 AS foundry
+
+# check for fresh version hash here: https://hub.docker.com/_/ubuntu
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends curl ca-certificates git jq && \

--- a/contracts/ethereum/foundry.lock
+++ b/contracts/ethereum/foundry.lock
@@ -4,5 +4,11 @@
       "name": "v1.15.0",
       "rev": "0844d7e1fc5e60d77b68e469bff60265f236c398"
     }
+  },
+  "lib/openzeppelin-contracts": {
+    "tag": {
+      "name": "v5.6.1",
+      "rev": "5fd1781b1454fd1ef8e722282f86f9293cacf256"
+    }
   }
 }

--- a/contracts/ethereum/src/Bridge.sol
+++ b/contracts/ethereum/src/Bridge.sol
@@ -15,7 +15,8 @@ interface IBridge {
         uint64 indexed eventId,
         address indexed sender,
         address[] tokens,
-        uint256[] amounts
+        uint256[] amounts,
+        bytes[] keys
     );
     event Signed(uint64 eventId, address indexed sender, uint64 actionId);
     // forge-lint: disable-next-line(mixed-case-function)
@@ -45,6 +46,12 @@ contract Bridge is IBridge, BridgeBase, BridgeActions, ReentrancyGuard {
     );
     error ERC20TransferFailed(address token, address from, uint256 amount);
     error RegularFundsLengthMismatch(uint256 tokens, uint256 amounts);
+    error InvalidRegularKey(uint256 index, bytes key);
+    error InvalidRegularKeySignature(
+        uint256 index,
+        address expected,
+        address received
+    );
 
     constructor(
         bytes memory processor,
@@ -68,9 +75,10 @@ contract Bridge is IBridge, BridgeBase, BridgeActions, ReentrancyGuard {
     receive() external payable {
         address[] memory tokens = new address[](1);
         uint256[] memory amounts = new uint256[](1);
+        bytes[] memory keys = new bytes[](0);
         tokens[0] = address(0);
         amounts[0] = msg.value;
-        emit FundsReceived(nextEventId, msg.sender, tokens, amounts);
+        emit FundsReceived(nextEventId, msg.sender, tokens, amounts, keys);
         nextEventId += 1;
     }
 
@@ -79,10 +87,28 @@ contract Bridge is IBridge, BridgeBase, BridgeActions, ReentrancyGuard {
         uint256[] calldata amounts,
         bytes[] calldata keys
     ) external nonReentrant {
-        keys;
         uint256 transferCount = tokens.length;
         if (transferCount != amounts.length) {
             revert RegularFundsLengthMismatch(transferCount, amounts.length);
+        }
+
+        bytes32 regularHash = sha256(abi.encodePacked(msg.sender));
+        uint256 regularKeyCount = keys.length;
+        bytes[] memory regularKeys = new bytes[](regularKeyCount);
+        for (uint256 i = 0; i < regularKeyCount; i++) {
+            (bytes memory key, bytes memory signature) = abi.decode(
+                keys[i],
+                (bytes, bytes)
+            );
+            if (!_isValidSecp256k1Pubkey(key)) {
+                revert InvalidRegularKey(i, key);
+            }
+            address expected = _validatorAddress(key);
+            address received = _recoverSigner(regularHash, signature);
+            if (received != expected) {
+                revert InvalidRegularKeySignature(i, expected, received);
+            }
+            regularKeys[i] = key;
         }
 
         for (uint256 i = 0; i < transferCount; i++) {
@@ -104,7 +130,7 @@ contract Bridge is IBridge, BridgeBase, BridgeActions, ReentrancyGuard {
             }
         }
 
-        emit FundsReceived(nextEventId, msg.sender, tokens, amounts);
+        emit FundsReceived(nextEventId, msg.sender, tokens, amounts, regularKeys);
         nextEventId += 1;
     }
 

--- a/contracts/ethereum/src/Bridge.sol
+++ b/contracts/ethereum/src/Bridge.sol
@@ -6,12 +6,16 @@ import {BridgeBase} from "./BridgeBase.sol";
 import {
     ReentrancyGuard
 } from "../lib/openzeppelin-contracts/contracts/utils/ReentrancyGuard.sol";
+import {
+    IERC20
+} from "../lib/openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
 
 interface IBridge {
     event FundsReceived(
         uint64 indexed eventId,
         address indexed sender,
-        uint256 amount
+        address[] tokens,
+        uint256[] amounts
     );
     event Signed(uint64 eventId, address indexed sender, uint64 actionId);
     // forge-lint: disable-next-line(mixed-case-function)
@@ -32,6 +36,15 @@ interface IBridge {
 contract Bridge is IBridge, BridgeBase, BridgeActions, ReentrancyGuard {
     error IncorrectActionId(uint64 expected, uint64 received);
     error InvalidProcessorSignature(address expected, address received);
+    error InvalidDepositToken(address token);
+    error InsufficientAllowance(
+        address token,
+        address owner,
+        uint256 allowed,
+        uint256 required
+    );
+    error ERC20TransferFailed(address token, address from, uint256 amount);
+    error RegularFundsLengthMismatch(uint256 tokens, uint256 amounts);
 
     constructor(
         bytes memory processor,
@@ -53,7 +66,45 @@ contract Bridge is IBridge, BridgeBase, BridgeActions, ReentrancyGuard {
     }
 
     receive() external payable {
-        emit FundsReceived(nextEventId, msg.sender, msg.value);
+        address[] memory tokens = new address[](1);
+        uint256[] memory amounts = new uint256[](1);
+        tokens[0] = address(0);
+        amounts[0] = msg.value;
+        emit FundsReceived(nextEventId, msg.sender, tokens, amounts);
+        nextEventId += 1;
+    }
+
+    function regular(
+        address[] calldata tokens,
+        uint256[] calldata amounts,
+        bytes[] calldata keys
+    ) external nonReentrant {
+        keys;
+        uint256 transferCount = tokens.length;
+        if (transferCount != amounts.length) {
+            revert RegularFundsLengthMismatch(transferCount, amounts.length);
+        }
+
+        for (uint256 i = 0; i < transferCount; i++) {
+            address token = tokens[i];
+            uint256 amount = amounts[i];
+            // regular() is ERC20-only; native ETH deposits use receive().
+            if (token == address(0)) {
+                revert InvalidDepositToken(token);
+            }
+
+            IERC20 erc20 = IERC20(token);
+            uint256 allowed = erc20.allowance(msg.sender, address(this));
+            if (allowed < amount) {
+                revert InsufficientAllowance(token, msg.sender, allowed, amount);
+            }
+            bool success = erc20.transferFrom(msg.sender, address(this), amount);
+            if (!success) {
+                revert ERC20TransferFailed(token, msg.sender, amount);
+            }
+        }
+
+        emit FundsReceived(nextEventId, msg.sender, tokens, amounts);
         nextEventId += 1;
     }
 

--- a/contracts/ethereum/src/Bridge.sol
+++ b/contracts/ethereum/src/Bridge.sol
@@ -3,6 +3,9 @@ pragma solidity ^0.8.30;
 
 import {BridgeActions} from "./BridgeActions.sol";
 import {BridgeBase} from "./BridgeBase.sol";
+import {
+    ReentrancyGuard
+} from "../lib/openzeppelin-contracts/contracts/utils/ReentrancyGuard.sol";
 
 interface IBridge {
     event FundsReceived(
@@ -26,7 +29,7 @@ interface IBridge {
         );
 }
 
-contract Bridge is IBridge, BridgeBase, BridgeActions {
+contract Bridge is IBridge, BridgeBase, BridgeActions, ReentrancyGuard {
     error IncorrectActionId(uint64 expected, uint64 received);
     error InvalidProcessorSignature(address expected, address received);
 
@@ -59,7 +62,7 @@ contract Bridge is IBridge, BridgeBase, BridgeActions {
         bytes calldata payload,
         bytes calldata processor,
         bytes[] calldata approvers
-    ) external {
+    ) external nonReentrant {
         (uint64 actionId, bytes memory actionData) = abi.decode(
             payload,
             (uint64, bytes)

--- a/contracts/ethereum/src/Bridge.sol
+++ b/contracts/ethereum/src/Bridge.sol
@@ -37,7 +37,6 @@ interface IBridge {
 contract Bridge is IBridge, BridgeBase, BridgeActions, ReentrancyGuard {
     error IncorrectActionId(uint64 expected, uint64 received);
     error InvalidProcessorSignature(address expected, address received);
-    error InvalidDepositToken(address token);
     error InsufficientAllowance(
         address token,
         address owner,
@@ -46,6 +45,7 @@ contract Bridge is IBridge, BridgeBase, BridgeActions, ReentrancyGuard {
     );
     error ERC20TransferFailed(address token, address from, uint256 amount);
     error RegularFundsLengthMismatch(uint256 tokens, uint256 amounts);
+    error EthValueMismatch(uint256 expected, uint256 received);
     error InvalidRegularKey(uint256 index, bytes key);
     error InvalidRegularKeySignature(
         uint256 index,
@@ -72,21 +72,11 @@ contract Bridge is IBridge, BridgeBase, BridgeActions, ReentrancyGuard {
         nextActionId = 0;
     }
 
-    receive() external payable {
-        address[] memory tokens = new address[](1);
-        uint256[] memory amounts = new uint256[](1);
-        bytes[] memory keys = new bytes[](0);
-        tokens[0] = address(0);
-        amounts[0] = msg.value;
-        emit FundsReceived(nextEventId, msg.sender, tokens, amounts, keys);
-        nextEventId += 1;
-    }
-
     function regular(
         address[] calldata tokens,
         uint256[] calldata amounts,
         bytes[] calldata keys
-    ) external nonReentrant {
+    ) external payable nonReentrant {
         uint256 transferCount = tokens.length;
         if (transferCount != amounts.length) {
             revert RegularFundsLengthMismatch(transferCount, amounts.length);
@@ -111,12 +101,14 @@ contract Bridge is IBridge, BridgeBase, BridgeActions, ReentrancyGuard {
             regularKeys[i] = key;
         }
 
+        uint256 ethExpectedValue = 0;
         for (uint256 i = 0; i < transferCount; i++) {
             address token = tokens[i];
             uint256 amount = amounts[i];
-            // regular() is ERC20-only; native ETH deposits use receive().
+            // Native ETH leg, value is checked after iterating all entries.
             if (token == address(0)) {
-                revert InvalidDepositToken(token);
+                ethExpectedValue += amount;
+                continue;
             }
 
             IERC20 erc20 = IERC20(token);
@@ -128,6 +120,10 @@ contract Bridge is IBridge, BridgeBase, BridgeActions, ReentrancyGuard {
             if (!success) {
                 revert ERC20TransferFailed(token, msg.sender, amount);
             }
+        }
+
+        if (msg.value != ethExpectedValue) {
+            revert EthValueMismatch(ethExpectedValue, msg.value);
         }
 
         emit FundsReceived(nextEventId, msg.sender, tokens, amounts, regularKeys);

--- a/contracts/ethereum/src/Bridge.sol
+++ b/contracts/ethereum/src/Bridge.sol
@@ -37,6 +37,7 @@ interface IBridge {
 contract Bridge is IBridge, BridgeBase, BridgeActions, ReentrancyGuard {
     error IncorrectActionId(uint64 expected, uint64 received);
     error InvalidProcessorSignature(address expected, address received);
+    error InvalidDepositToken(address token);
     error InsufficientAllowance(
         address token,
         address owner,
@@ -45,7 +46,6 @@ contract Bridge is IBridge, BridgeBase, BridgeActions, ReentrancyGuard {
     );
     error ERC20TransferFailed(address token, address from, uint256 amount);
     error RegularFundsLengthMismatch(uint256 tokens, uint256 amounts);
-    error EthValueMismatch(uint256 expected, uint256 received);
     error InvalidRegularKey(uint256 index, bytes key);
     error InvalidRegularKeySignature(
         uint256 index,
@@ -101,32 +101,54 @@ contract Bridge is IBridge, BridgeBase, BridgeActions, ReentrancyGuard {
             regularKeys[i] = key;
         }
 
-        uint256 ethExpectedValue = 0;
         for (uint256 i = 0; i < transferCount; i++) {
             address token = tokens[i];
             uint256 amount = amounts[i];
-            // Native ETH leg, value is checked after iterating all entries.
+
+            // ETH is in msg.value
             if (token == address(0)) {
-                ethExpectedValue += amount;
-                continue;
+                revert InvalidDepositToken(token);
             }
 
             IERC20 erc20 = IERC20(token);
             uint256 allowed = erc20.allowance(msg.sender, address(this));
             if (allowed < amount) {
-                revert InsufficientAllowance(token, msg.sender, allowed, amount);
+                revert InsufficientAllowance(
+                    token,
+                    msg.sender,
+                    allowed,
+                    amount
+                );
             }
-            bool success = erc20.transferFrom(msg.sender, address(this), amount);
+            bool success = erc20.transferFrom(
+                msg.sender,
+                address(this),
+                amount
+            );
             if (!success) {
                 revert ERC20TransferFailed(token, msg.sender, amount);
             }
         }
 
-        if (msg.value != ethExpectedValue) {
-            revert EthValueMismatch(ethExpectedValue, msg.value);
+        uint256 eventTransferCount = transferCount + (msg.value > 0 ? 1 : 0);
+        address[] memory eventTokens = new address[](eventTransferCount);
+        uint256[] memory eventAmounts = new uint256[](eventTransferCount);
+        for (uint256 i = 0; i < transferCount; i++) {
+            eventTokens[i] = tokens[i];
+            eventAmounts[i] = amounts[i];
+        }
+        if (msg.value > 0) {
+            eventTokens[transferCount] = address(0);
+            eventAmounts[transferCount] = msg.value;
         }
 
-        emit FundsReceived(nextEventId, msg.sender, tokens, amounts, regularKeys);
+        emit FundsReceived(
+            nextEventId,
+            msg.sender,
+            eventTokens,
+            eventAmounts,
+            regularKeys
+        );
         nextEventId += 1;
     }
 

--- a/contracts/ethereum/src/BridgeActions.sol
+++ b/contracts/ethereum/src/BridgeActions.sol
@@ -4,9 +4,9 @@ pragma solidity ^0.8.30;
 import {BridgeBase} from "./BridgeBase.sol";
 
 abstract contract BridgeActions is BridgeBase {
-    uint8 internal constant ACTION_SELF_REPLACE = 2;
-    uint8 internal constant ACTION_NEW_SET = 3;
-    uint8 internal constant ACTION_EXECUTE = 4;
+    uint8 internal constant ACTION_EXECUTE = 0;
+    uint8 internal constant ACTION_SELF_REPLACE = 1;
+    uint8 internal constant ACTION_NEW_SET = 2;
 
     uint8 internal constant VALIDATOR_LISTENER = 0;
     uint8 internal constant VALIDATOR_PROCESSOR = 1;

--- a/contracts/ethereum/src/BridgeActions.sol
+++ b/contracts/ethereum/src/BridgeActions.sol
@@ -4,8 +4,6 @@ pragma solidity ^0.8.30;
 import {BridgeBase} from "./BridgeBase.sol";
 
 abstract contract BridgeActions is BridgeBase {
-    uint8 internal constant ACTION_TRANSFER_ETH = 0;
-    uint8 internal constant ACTION_TRANSFER_ERC20 = 1;
     uint8 internal constant ACTION_SELF_REPLACE = 2;
     uint8 internal constant ACTION_NEW_SET = 3;
     uint8 internal constant ACTION_EXECUTE = 4;
@@ -17,7 +15,6 @@ abstract contract BridgeActions is BridgeBase {
     error InvalidActionType(uint8 actionType);
     error InvalidValidatorType(uint8 validatorType);
     error CurrentValidatorNotFound(uint8 validatorType, bytes current);
-    error TransferEthFailed(address recipient, uint256 amount);
     error ExecuteCallFailed(address target, uint256 value, bytes data);
     error InvalidNewSetApprovalSignature(address signer);
     error DuplicateNewSetApprovalSignature(address signer);
@@ -62,12 +59,6 @@ abstract contract BridgeActions is BridgeBase {
             neededApprovers;
 
             _verifyNewSetApprovals(rendered, approvals);
-            return;
-        }
-        if (
-            actionType == ACTION_TRANSFER_ETH ||
-            actionType == ACTION_TRANSFER_ERC20
-        ) {
             return;
         }
         if (actionType == ACTION_EXECUTE) {
@@ -156,10 +147,6 @@ abstract contract BridgeActions is BridgeBase {
             actionData,
             (uint8, bytes)
         );
-        if (actionType == ACTION_TRANSFER_ETH) {
-            _executeTransferEth(data);
-            return;
-        }
         if (actionType == ACTION_EXECUTE) {
             _executeCall(data);
             return;
@@ -174,17 +161,6 @@ abstract contract BridgeActions is BridgeBase {
         }
 
         revert InvalidActionType(actionType);
-    }
-
-    function _executeTransferEth(bytes memory data) internal {
-        (address recipient, uint256 amount) = abi.decode(
-            data,
-            (address, uint256)
-        );
-        (bool success, ) = recipient.call{value: amount}("");
-        if (!success) {
-            revert TransferEthFailed(recipient, amount);
-        }
     }
 
     function _executeCall(bytes memory data) internal {

--- a/contracts/ethereum/src/BridgeActions.sol
+++ b/contracts/ethereum/src/BridgeActions.sol
@@ -189,7 +189,7 @@ abstract contract BridgeActions is BridgeBase {
         bytes memory current,
         bytes memory replacement
     ) internal view {
-        if (!_isValidValidatorKey(replacement)) {
+        if (!_isValidSecp256k1Pubkey(replacement)) {
             revert InvalidValidatorKey(0, replacement);
         }
         _validatorAddress(replacement);

--- a/contracts/ethereum/src/BridgeActions.sol
+++ b/contracts/ethereum/src/BridgeActions.sol
@@ -8,6 +8,7 @@ abstract contract BridgeActions is BridgeBase {
     uint8 internal constant ACTION_TRANSFER_ERC20 = 1;
     uint8 internal constant ACTION_SELF_REPLACE = 2;
     uint8 internal constant ACTION_NEW_SET = 3;
+    uint8 internal constant ACTION_EXECUTE = 4;
 
     uint8 internal constant VALIDATOR_LISTENER = 0;
     uint8 internal constant VALIDATOR_PROCESSOR = 1;
@@ -17,6 +18,7 @@ abstract contract BridgeActions is BridgeBase {
     error InvalidValidatorType(uint8 validatorType);
     error CurrentValidatorNotFound(uint8 validatorType, bytes current);
     error TransferEthFailed(address recipient, uint256 amount);
+    error ExecuteCallFailed(address target, uint256 value, bytes data);
     error InvalidNewSetApprovalSignature(address signer);
     error DuplicateNewSetApprovalSignature(address signer);
     error InsufficientNewSetGroupSignatures(uint8 needed, uint8 provided);
@@ -66,6 +68,17 @@ abstract contract BridgeActions is BridgeBase {
             actionType == ACTION_TRANSFER_ETH ||
             actionType == ACTION_TRANSFER_ERC20
         ) {
+            return;
+        }
+        if (actionType == ACTION_EXECUTE) {
+            (address target, uint256 value, bytes memory callData) = abi.decode(
+                data,
+                (address, uint256, bytes)
+            );
+            // no-ops to silence compiler warnings - we want to validate full ABI shape
+            target;
+            value;
+            callData;
             return;
         }
         revert InvalidActionType(actionType);
@@ -147,6 +160,10 @@ abstract contract BridgeActions is BridgeBase {
             _executeTransferEth(data);
             return;
         }
+        if (actionType == ACTION_EXECUTE) {
+            _executeCall(data);
+            return;
+        }
         if (actionType == ACTION_SELF_REPLACE) {
             _executeSelfReplace(data);
             return;
@@ -167,6 +184,17 @@ abstract contract BridgeActions is BridgeBase {
         (bool success, ) = recipient.call{value: amount}("");
         if (!success) {
             revert TransferEthFailed(recipient, amount);
+        }
+    }
+
+    function _executeCall(bytes memory data) internal {
+        (address target, uint256 value, bytes memory callData) = abi.decode(
+            data,
+            (address, uint256, bytes)
+        );
+        (bool success, ) = target.call{value: value}(callData);
+        if (!success) {
+            revert ExecuteCallFailed(target, value, callData);
         }
     }
 

--- a/contracts/ethereum/src/BridgeBase.sol
+++ b/contracts/ethereum/src/BridgeBase.sol
@@ -39,7 +39,7 @@ abstract contract BridgeBase {
     uint256 internal constant SECP256K1_SQRT_EXP =
         0x3FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFBFFFFF0C;
 
-    function _isValidValidatorKey(
+    function _isValidSecp256k1Pubkey(
         bytes memory key
     ) internal pure returns (bool) {
         return key.length == 33 && (key[0] == 0x02 || key[0] == 0x03);
@@ -62,7 +62,7 @@ abstract contract BridgeBase {
         bytes[] memory approvers,
         uint16 neededApprovers
     ) internal {
-        if (!_isValidValidatorKey(processor)) {
+        if (!_isValidSecp256k1Pubkey(processor)) {
             revert InvalidProcessorKey(processor);
         }
         _validatorAddress(processor);
@@ -70,7 +70,7 @@ abstract contract BridgeBase {
             revert EmptyListeners();
         }
         for (uint256 i = 0; i < listeners.length; i++) {
-            if (!_isValidValidatorKey(listeners[i])) {
+            if (!_isValidSecp256k1Pubkey(listeners[i])) {
                 revert InvalidValidatorKey(i, listeners[i]);
             }
             _validatorAddress(listeners[i]);
@@ -83,7 +83,7 @@ abstract contract BridgeBase {
             revert EmptyApprovers();
         }
         for (uint256 i = 0; i < approvers.length; i++) {
-            if (!_isValidValidatorKey(approvers[i])) {
+            if (!_isValidSecp256k1Pubkey(approvers[i])) {
                 revert InvalidValidatorKey(i, approvers[i]);
             }
             _validatorAddress(approvers[i]);
@@ -110,7 +110,7 @@ abstract contract BridgeBase {
     function _validatorAddress(
         bytes memory key
     ) internal view returns (address) {
-        if (!_isValidValidatorKey(key)) {
+        if (!_isValidSecp256k1Pubkey(key)) {
             revert InvalidCurvePoint(key);
         }
         uint256 x = 0;

--- a/contracts/ethereum/src/mocks/TestERC20Mintable.sol
+++ b/contracts/ethereum/src/mocks/TestERC20Mintable.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {ERC20} from "../../lib/openzeppelin-contracts/contracts/token/ERC20/ERC20.sol";
+
+contract TestERC20Mintable is ERC20 {
+    constructor(string memory name_, string memory symbol_) ERC20(name_, symbol_) {}
+
+    function mint(address to, uint256 amount) external {
+        _mint(to, amount);
+    }
+}

--- a/contracts/ethereum/test/Bridge.t.sol
+++ b/contracts/ethereum/test/Bridge.t.sol
@@ -12,6 +12,49 @@ contract RevertingReceiver {
     }
 }
 
+// A contract designed to be called from bridge's execute_signed() entry point and
+// calling it back, triggering reentrancy guard, and ensuring that expected error was hit
+contract ReentrantExecuteSignedCaller {
+    Bridge private immutable BRIDGE;
+    bytes4 private constant REENTRANCY_GUARD_SELECTOR =
+        bytes4(keccak256("ReentrancyGuardReentrantCall()"));
+
+    constructor(Bridge bridge_) {
+        BRIDGE = bridge_;
+    }
+
+    function reenter() external returns (bool) {
+        bytes[] memory emptyApprovers = new bytes[](0);
+        (bool ok, bytes memory ret) = address(BRIDGE).call(
+            abi.encodeWithSelector(
+                Bridge.execute_signed.selector,
+                bytes(""),
+                bytes(""),
+                emptyApprovers
+            )
+        );
+
+        if (ok) {
+            revert("expected revert");
+        }
+
+        // check that the failure is reentrancy guard error
+        if (ret.length < 4) {
+            revert("missing selector");
+        }
+
+        bytes4 selector;
+        assembly {
+            // first 32 bytes of ret's memory storage is its length
+            selector := mload(add(ret, 0x20))
+        }
+        if (selector != REENTRANCY_GUARD_SELECTOR) {
+            revert("unexpected selector");
+        }
+        return true;
+    }
+}
+
 contract BridgeRecoverHarness is Bridge {
     constructor(
         bytes memory processor,
@@ -393,6 +436,34 @@ contract BridgeTest is Test {
             )
         );
         bridge.execute_signed(payload, processorSig, approverSigs);
+    }
+
+    function test_ExecuteSignedRejectsReentrantExecuteSignedCall() public {
+        ReentrantExecuteSignedCaller reentrant = new ReentrantExecuteSignedCaller(
+                bridge
+            );
+        bytes memory actionData = abi.encode(
+            ACTION_EXECUTE,
+            abi.encode(
+                address(reentrant),
+                uint256(0),
+                abi.encodeWithSignature("reenter()")
+            )
+        );
+        bytes memory payload = abi.encode(uint64(0), actionData);
+        bytes memory processorSig = _signPayload(
+            PROCESSOR_PRIVATE_KEY,
+            payload
+        );
+        bytes[] memory approverSigs = new bytes[](1);
+        approverSigs[0] = _signPayload(APPROVER_PRIVATE_KEY, payload);
+
+        bridge.execute_signed(payload, processorSig, approverSigs);
+
+        (, , , , , uint64 configNextEventId, uint64 configNextActionId) = bridge
+            .get_config();
+        assertEq(configNextEventId, 2);
+        assertEq(configNextActionId, 1);
     }
 
     function test_ExecuteSignedSelfReplaceProcessorAction() public {

--- a/contracts/ethereum/test/Bridge.t.sol
+++ b/contracts/ethereum/test/Bridge.t.sol
@@ -146,7 +146,8 @@ contract BridgeTest is Test {
         uint64 indexed eventId,
         address indexed sender,
         address[] tokens,
-        uint256[] amounts
+        uint256[] amounts,
+        bytes[] keys
     );
     event Signed(uint64 eventId, address indexed sender, uint64 actionId);
     bytes constant TEST_VALIDATOR_KEY =
@@ -198,11 +199,12 @@ contract BridgeTest is Test {
         vm.deal(nonAdmin, 1 ether);
         address[] memory tokens = new address[](1);
         uint256[] memory amounts = new uint256[](1);
+        bytes[] memory keys = new bytes[](0);
         tokens[0] = address(0);
         amounts[0] = 0.1 ether;
 
         vm.expectEmit(true, true, false, true, address(bridge));
-        emit FundsReceived(1, nonAdmin, tokens, amounts);
+        emit FundsReceived(1, nonAdmin, tokens, amounts, keys);
 
         vm.prank(nonAdmin);
         (bool ok, ) = address(bridge).call{value: 0.1 ether}("");
@@ -230,9 +232,13 @@ contract BridgeTest is Test {
         uint256[] memory amounts = new uint256[](1);
         tokens[0] = address(token);
         amounts[0] = 70;
-        bytes[] memory keys = new bytes[](0);
+        bytes[] memory keys = new bytes[](1);
+        keys[0] = abi.encode(
+            TEST_VALIDATOR_KEY,
+            _signRegularMessage(PROCESSOR_PRIVATE_KEY, nonAdmin)
+        );
         vm.expectEmit(true, true, false, true, address(bridge));
-        emit FundsReceived(1, nonAdmin, tokens, amounts);
+        emit FundsReceived(1, nonAdmin, tokens, amounts, _eventKeys(keys));
 
         vm.prank(nonAdmin);
         bridge.regular(tokens, amounts, keys);
@@ -242,6 +248,63 @@ contract BridgeTest is Test {
 
         (, , , , , uint64 configNextEventId, ) = bridge.get_config();
         assertEq(configNextEventId, 2);
+    }
+
+    function test_RevertWhenRegularKeyInvalid() public {
+        MockERC20 token = new MockERC20();
+        token.mint(nonAdmin, 100);
+
+        vm.prank(nonAdmin);
+        assertTrue(token.approve(address(bridge), 10));
+
+        address[] memory tokens = new address[](1);
+        uint256[] memory amounts = new uint256[](1);
+        tokens[0] = address(token);
+        amounts[0] = 10;
+        bytes[] memory keys = new bytes[](1);
+        keys[0] = abi.encode(
+            bytes("short"),
+            _signRegularMessage(PROCESSOR_PRIVATE_KEY, nonAdmin)
+        );
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                Bridge.InvalidRegularKey.selector,
+                uint256(0),
+                bytes("short")
+            )
+        );
+        vm.prank(nonAdmin);
+        bridge.regular(tokens, amounts, keys);
+    }
+
+    function test_RevertWhenRegularKeySignatureMismatch() public {
+        MockERC20 token = new MockERC20();
+        token.mint(nonAdmin, 100);
+
+        vm.prank(nonAdmin);
+        assertTrue(token.approve(address(bridge), 10));
+
+        address[] memory tokens = new address[](1);
+        uint256[] memory amounts = new uint256[](1);
+        tokens[0] = address(token);
+        amounts[0] = 10;
+        bytes[] memory keys = new bytes[](1);
+        keys[0] = abi.encode(
+            TEST_VALIDATOR_KEY,
+            _signRegularMessage(APPROVER_PRIVATE_KEY, nonAdmin)
+        );
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                Bridge.InvalidRegularKeySignature.selector,
+                uint256(0),
+                vm.addr(PROCESSOR_PRIVATE_KEY),
+                vm.addr(APPROVER_PRIVATE_KEY)
+            )
+        );
+        vm.prank(nonAdmin);
+        bridge.regular(tokens, amounts, keys);
     }
 
     function test_RevertWhenRegularDepositTokenZero() public {
@@ -340,10 +403,14 @@ contract BridgeTest is Test {
         tokens[1] = address(tokenB);
         amounts[0] = 40;
         amounts[1] = 20;
-        bytes[] memory keys = new bytes[](0);
+        bytes[] memory keys = new bytes[](1);
+        keys[0] = abi.encode(
+            TEST_VALIDATOR_KEY,
+            _signRegularMessage(PROCESSOR_PRIVATE_KEY, nonAdmin)
+        );
 
         vm.expectEmit(true, true, false, true, address(bridge));
-        emit FundsReceived(1, nonAdmin, tokens, amounts);
+        emit FundsReceived(1, nonAdmin, tokens, amounts, _eventKeys(keys));
 
         vm.prank(nonAdmin);
         bridge.regular(tokens, amounts, keys);
@@ -1112,5 +1179,24 @@ contract BridgeTest is Test {
         bytes32 hash = sha256(payload);
         (uint8 v, bytes32 r, bytes32 s) = vm.sign(privateKey, hash);
         return abi.encodePacked(r, s, v);
+    }
+
+    function _signRegularMessage(
+        uint256 privateKey,
+        address wallet
+    ) internal returns (bytes memory) {
+        bytes32 hash = sha256(abi.encodePacked(wallet));
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(privateKey, hash);
+        return abi.encodePacked(r, s, v);
+    }
+
+    function _eventKeys(
+        bytes[] memory encodedKeys
+    ) internal pure returns (bytes[] memory out) {
+        out = new bytes[](encodedKeys.length);
+        for (uint256 i = 0; i < encodedKeys.length; i++) {
+            (bytes memory key, ) = abi.decode(encodedKeys[i], (bytes, bytes));
+            out[i] = key;
+        }
     }
 }

--- a/contracts/ethereum/test/Bridge.t.sol
+++ b/contracts/ethereum/test/Bridge.t.sol
@@ -6,6 +6,56 @@ import {Bridge} from "../src/Bridge.sol";
 import {BridgeActions} from "../src/BridgeActions.sol";
 import {BridgeBase} from "../src/BridgeBase.sol";
 
+contract MockERC20 {
+    mapping(address => uint256) internal balances;
+    mapping(address => mapping(address => uint256)) internal allowances;
+
+    function mint(address to, uint256 amount) external {
+        balances[to] += amount;
+    }
+
+    function balanceOf(address account) external view returns (uint256) {
+        return balances[account];
+    }
+
+    function allowance(
+        address owner,
+        address spender
+    ) external view returns (uint256) {
+        return allowances[owner][spender];
+    }
+
+    function approve(address spender, uint256 amount) external returns (bool) {
+        allowances[msg.sender][spender] = amount;
+        return true;
+    }
+
+    function transferFrom(
+        address from,
+        address to,
+        uint256 amount
+    ) external virtual returns (bool) {
+        uint256 allowed = allowances[from][msg.sender];
+        if (allowed < amount || balances[from] < amount) {
+            return false;
+        }
+        allowances[from][msg.sender] = allowed - amount;
+        balances[from] -= amount;
+        balances[to] += amount;
+        return true;
+    }
+}
+
+contract MockERC20TransferFromFalse is MockERC20 {
+    function transferFrom(
+        address,
+        address,
+        uint256
+    ) external pure override returns (bool) {
+        return false;
+    }
+}
+
 contract RevertingReceiver {
     receive() external payable {
         revert("reject");
@@ -95,7 +145,8 @@ contract BridgeTest is Test {
     event FundsReceived(
         uint64 indexed eventId,
         address indexed sender,
-        uint256 amount
+        address[] tokens,
+        uint256[] amounts
     );
     event Signed(uint64 eventId, address indexed sender, uint64 actionId);
     bytes constant TEST_VALIDATOR_KEY =
@@ -145,9 +196,13 @@ contract BridgeTest is Test {
 
     function test_ReceiveEthEmitsEvent() public {
         vm.deal(nonAdmin, 1 ether);
+        address[] memory tokens = new address[](1);
+        uint256[] memory amounts = new uint256[](1);
+        tokens[0] = address(0);
+        amounts[0] = 0.1 ether;
 
         vm.expectEmit(true, true, false, true, address(bridge));
-        emit FundsReceived(1, nonAdmin, 0.1 ether);
+        emit FundsReceived(1, nonAdmin, tokens, amounts);
 
         vm.prank(nonAdmin);
         (bool ok, ) = address(bridge).call{value: 0.1 ether}("");
@@ -162,6 +217,139 @@ contract BridgeTest is Test {
 
         (, , , , , uint64 configNextEventId, ) = bridge.get_config();
         assertEq(configNextEventId, 2);
+    }
+
+    function test_RegularErc20EmitsEventAndUpdatesBalances() public {
+        MockERC20 token = new MockERC20();
+        token.mint(nonAdmin, 100);
+
+        vm.prank(nonAdmin);
+        assertTrue(token.approve(address(bridge), 70));
+
+        address[] memory tokens = new address[](1);
+        uint256[] memory amounts = new uint256[](1);
+        tokens[0] = address(token);
+        amounts[0] = 70;
+        bytes[] memory keys = new bytes[](0);
+        vm.expectEmit(true, true, false, true, address(bridge));
+        emit FundsReceived(1, nonAdmin, tokens, amounts);
+
+        vm.prank(nonAdmin);
+        bridge.regular(tokens, amounts, keys);
+
+        assertEq(token.balanceOf(address(bridge)), 70);
+        assertEq(token.balanceOf(nonAdmin), 30);
+
+        (, , , , , uint64 configNextEventId, ) = bridge.get_config();
+        assertEq(configNextEventId, 2);
+    }
+
+    function test_RevertWhenRegularDepositTokenZero() public {
+        address[] memory tokens = new address[](1);
+        uint256[] memory amounts = new uint256[](1);
+        tokens[0] = address(0);
+        amounts[0] = 1;
+        bytes[] memory keys = new bytes[](0);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                Bridge.InvalidDepositToken.selector,
+                address(0)
+            )
+        );
+        bridge.regular(tokens, amounts, keys);
+    }
+
+    function test_RevertWhenRegularAllowanceInsufficient() public {
+        MockERC20 token = new MockERC20();
+        token.mint(nonAdmin, 100);
+        address[] memory tokens = new address[](1);
+        uint256[] memory amounts = new uint256[](1);
+        tokens[0] = address(token);
+        amounts[0] = 10;
+        bytes[] memory keys = new bytes[](0);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                Bridge.InsufficientAllowance.selector,
+                address(token),
+                nonAdmin,
+                uint256(0),
+                uint256(10)
+            )
+        );
+        vm.prank(nonAdmin);
+        bridge.regular(tokens, amounts, keys);
+    }
+
+    function test_RevertWhenRegularTransferFromFails() public {
+        MockERC20TransferFromFalse token = new MockERC20TransferFromFalse();
+        token.mint(nonAdmin, 100);
+
+        vm.prank(nonAdmin);
+        assertTrue(token.approve(address(bridge), 10));
+
+        address[] memory tokens = new address[](1);
+        uint256[] memory amounts = new uint256[](1);
+        tokens[0] = address(token);
+        amounts[0] = 10;
+        bytes[] memory keys = new bytes[](0);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                Bridge.ERC20TransferFailed.selector,
+                address(token),
+                nonAdmin,
+                uint256(10)
+            )
+        );
+        vm.prank(nonAdmin);
+        bridge.regular(tokens, amounts, keys);
+    }
+
+    function test_RevertWhenRegularFundsLengthMismatch() public {
+        address[] memory tokens = new address[](2);
+        uint256[] memory amounts = new uint256[](1);
+        tokens[0] = address(1);
+        tokens[1] = address(2);
+        amounts[0] = 1;
+        bytes[] memory keys = new bytes[](0);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                Bridge.RegularFundsLengthMismatch.selector,
+                uint256(2),
+                uint256(1)
+            )
+        );
+        bridge.regular(tokens, amounts, keys);
+    }
+
+    function test_RegularErc20BatchTransfers() public {
+        MockERC20 tokenA = new MockERC20();
+        MockERC20 tokenB = new MockERC20();
+        tokenA.mint(nonAdmin, 100);
+        tokenB.mint(nonAdmin, 50);
+
+        vm.startPrank(nonAdmin);
+        assertTrue(tokenA.approve(address(bridge), 40));
+        assertTrue(tokenB.approve(address(bridge), 20));
+        vm.stopPrank();
+
+        address[] memory tokens = new address[](2);
+        uint256[] memory amounts = new uint256[](2);
+        tokens[0] = address(tokenA);
+        tokens[1] = address(tokenB);
+        amounts[0] = 40;
+        amounts[1] = 20;
+        bytes[] memory keys = new bytes[](0);
+
+        vm.expectEmit(true, true, false, true, address(bridge));
+        emit FundsReceived(1, nonAdmin, tokens, amounts);
+
+        vm.prank(nonAdmin);
+        bridge.regular(tokens, amounts, keys);
+
+        assertEq(tokenA.balanceOf(address(bridge)), 40);
+        assertEq(tokenB.balanceOf(address(bridge)), 20);
     }
 
     function test_ExecuteSignedIncrementsIdsAndEmitsEvent() public {

--- a/contracts/ethereum/test/Bridge.t.sol
+++ b/contracts/ethereum/test/Bridge.t.sol
@@ -196,16 +196,34 @@ contract BridgeTest is Test {
         );
     }
 
-    function test_ReceiveEth() public {
+    function test_RevertWhenReceiveEthDirectTransfer() public {
         vm.deal(nonAdmin, 1 ether);
 
         vm.prank(nonAdmin);
         (bool ok, ) = address(bridge).call{value: 0.25 ether}("");
-        assertTrue(ok);
-        assertEq(address(bridge).balance, 0.25 ether);
+        assertFalse(ok);
     }
 
-    function test_ReceiveEthEmitsEvent() public {
+    function test_RegularEthEmitsEvent() public {
+        vm.deal(nonAdmin, 1 ether);
+        address[] memory tokens = new address[](1);
+        uint256[] memory amounts = new uint256[](1);
+        bytes[] memory keys = new bytes[](1);
+        tokens[0] = address(0);
+        amounts[0] = 0.1 ether;
+        keys[0] = abi.encode(
+            TEST_VALIDATOR_KEY,
+            _signRegularMessage(PROCESSOR_PRIVATE_KEY, nonAdmin)
+        );
+
+        vm.expectEmit(true, true, false, true, address(bridge));
+        emit FundsReceived(1, nonAdmin, tokens, amounts, _eventKeys(keys));
+
+        vm.prank(nonAdmin);
+        bridge.regular{value: 0.1 ether}(tokens, amounts, keys);
+    }
+
+    function test_RegularEthIncrementsNextEventId() public {
         vm.deal(nonAdmin, 1 ether);
         address[] memory tokens = new address[](1);
         uint256[] memory amounts = new uint256[](1);
@@ -213,19 +231,8 @@ contract BridgeTest is Test {
         tokens[0] = address(0);
         amounts[0] = 0.1 ether;
 
-        vm.expectEmit(true, true, false, true, address(bridge));
-        emit FundsReceived(1, nonAdmin, tokens, amounts, keys);
-
         vm.prank(nonAdmin);
-        (bool ok, ) = address(bridge).call{value: 0.1 ether}("");
-        assertTrue(ok);
-    }
-
-    function test_ReceiveEthIncrementsNextEventId() public {
-        vm.deal(nonAdmin, 1 ether);
-        vm.prank(nonAdmin);
-        (bool ok, ) = address(bridge).call{value: 0.1 ether}("");
-        assertTrue(ok);
+        bridge.regular{value: 0.1 ether}(tokens, amounts, keys);
 
         (, , , , , uint64 configNextEventId, ) = bridge.get_config();
         assertEq(configNextEventId, 2);
@@ -317,19 +324,36 @@ contract BridgeTest is Test {
         bridge.regular(tokens, amounts, keys);
     }
 
-    function test_RevertWhenRegularDepositTokenZero() public {
+    function test_RevertWhenRegularEthValueMismatchMissingValue() public {
         address[] memory tokens = new address[](1);
         uint256[] memory amounts = new uint256[](1);
         tokens[0] = address(0);
         amounts[0] = 1;
         bytes[] memory keys = new bytes[](0);
+
         vm.expectRevert(
             abi.encodeWithSelector(
-                Bridge.InvalidDepositToken.selector,
-                address(0)
+                Bridge.EthValueMismatch.selector,
+                uint256(1),
+                uint256(0)
             )
         );
         bridge.regular(tokens, amounts, keys);
+    }
+
+    function test_RevertWhenRegularEthValueMismatchUnexpectedValue() public {
+        address[] memory tokens = new address[](0);
+        uint256[] memory amounts = new uint256[](0);
+        bytes[] memory keys = new bytes[](0);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                Bridge.EthValueMismatch.selector,
+                uint256(0),
+                uint256(1)
+            )
+        );
+        bridge.regular{value: 1}(tokens, amounts, keys);
     }
 
     function test_RevertWhenRegularAllowanceInsufficient() public {

--- a/contracts/ethereum/test/Bridge.t.sol
+++ b/contracts/ethereum/test/Bridge.t.sol
@@ -117,7 +117,10 @@ contract BridgeTest is Test {
     }
 
     function test_ExecuteSignedIncrementsIdsAndEmitsEvent() public {
-        bytes memory actionData = abi.encode(uint8(0), abi.encode(nonAdmin, 0));
+        bytes memory actionData = abi.encode(
+            uint8(4),
+            abi.encode(nonAdmin, 0, bytes(""))
+        );
         bytes memory payload = abi.encode(uint64(0), actionData);
         bytes memory processorSig = _signPayload(
             PROCESSOR_PRIVATE_KEY,

--- a/contracts/ethereum/test/Bridge.t.sol
+++ b/contracts/ethereum/test/Bridge.t.sol
@@ -6,6 +6,12 @@ import {Bridge} from "../src/Bridge.sol";
 import {BridgeActions} from "../src/BridgeActions.sol";
 import {BridgeBase} from "../src/BridgeBase.sol";
 
+contract RevertingReceiver {
+    receive() external payable {
+        revert("reject");
+    }
+}
+
 contract BridgeRecoverHarness is Bridge {
     constructor(
         bytes memory processor,
@@ -335,8 +341,8 @@ contract BridgeTest is Test {
         uint256 amount = 0.2 ether;
 
         bytes memory actionData = abi.encode(
-            uint8(0),
-            abi.encode(recipient, amount)
+            uint8(4),
+            abi.encode(recipient, amount, bytes(""))
         );
         bytes memory payload = abi.encode(uint64(0), actionData);
         bytes memory processorSig = _signPayload(
@@ -351,6 +357,34 @@ contract BridgeTest is Test {
 
         assertEq(recipient.balance, recipientBefore + amount);
         assertEq(address(bridge).balance, 1 ether - amount);
+    }
+
+    function test_RevertWhenExecuteActionCallFails() public {
+        vm.deal(address(bridge), 1 ether);
+        RevertingReceiver receiver = new RevertingReceiver();
+
+        bytes memory callData = abi.encodeWithSignature("doesNotExist()");
+        bytes memory actionData = abi.encode(
+            uint8(4),
+            abi.encode(address(receiver), 0, callData)
+        );
+        bytes memory payload = abi.encode(uint64(0), actionData);
+        bytes memory processorSig = _signPayload(
+            PROCESSOR_PRIVATE_KEY,
+            payload
+        );
+        bytes[] memory approverSigs = new bytes[](1);
+        approverSigs[0] = _signPayload(APPROVER_PRIVATE_KEY, payload);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                BridgeActions.ExecuteCallFailed.selector,
+                address(receiver),
+                uint256(0),
+                callData
+            )
+        );
+        bridge.execute_signed(payload, processorSig, approverSigs);
     }
 
     function test_ExecuteSignedSelfReplaceProcessorAction() public {

--- a/contracts/ethereum/test/Bridge.t.sol
+++ b/contracts/ethereum/test/Bridge.t.sol
@@ -206,18 +206,26 @@ contract BridgeTest is Test {
 
     function test_RegularEthEmitsEvent() public {
         vm.deal(nonAdmin, 1 ether);
-        address[] memory tokens = new address[](1);
-        uint256[] memory amounts = new uint256[](1);
+        address[] memory tokens = new address[](0);
+        uint256[] memory amounts = new uint256[](0);
         bytes[] memory keys = new bytes[](1);
-        tokens[0] = address(0);
-        amounts[0] = 0.1 ether;
+        address[] memory expectedTokens = new address[](1);
+        uint256[] memory expectedAmounts = new uint256[](1);
+        expectedTokens[0] = address(0);
+        expectedAmounts[0] = 0.1 ether;
         keys[0] = abi.encode(
             TEST_VALIDATOR_KEY,
             _signRegularMessage(PROCESSOR_PRIVATE_KEY, nonAdmin)
         );
 
         vm.expectEmit(true, true, false, true, address(bridge));
-        emit FundsReceived(1, nonAdmin, tokens, amounts, _eventKeys(keys));
+        emit FundsReceived(
+            1,
+            nonAdmin,
+            expectedTokens,
+            expectedAmounts,
+            _eventKeys(keys)
+        );
 
         vm.prank(nonAdmin);
         bridge.regular{value: 0.1 ether}(tokens, amounts, keys);
@@ -225,11 +233,9 @@ contract BridgeTest is Test {
 
     function test_RegularEthIncrementsNextEventId() public {
         vm.deal(nonAdmin, 1 ether);
-        address[] memory tokens = new address[](1);
-        uint256[] memory amounts = new uint256[](1);
+        address[] memory tokens = new address[](0);
+        uint256[] memory amounts = new uint256[](0);
         bytes[] memory keys = new bytes[](0);
-        tokens[0] = address(0);
-        amounts[0] = 0.1 ether;
 
         vm.prank(nonAdmin);
         bridge.regular{value: 0.1 ether}(tokens, amounts, keys);
@@ -324,7 +330,7 @@ contract BridgeTest is Test {
         bridge.regular(tokens, amounts, keys);
     }
 
-    function test_RevertWhenRegularEthValueMismatchMissingValue() public {
+    function test_RevertWhenRegularDepositTokenZero() public {
         address[] memory tokens = new address[](1);
         uint256[] memory amounts = new uint256[](1);
         tokens[0] = address(0);
@@ -333,27 +339,11 @@ contract BridgeTest is Test {
 
         vm.expectRevert(
             abi.encodeWithSelector(
-                Bridge.EthValueMismatch.selector,
-                uint256(1),
-                uint256(0)
+                Bridge.InvalidDepositToken.selector,
+                address(0)
             )
         );
         bridge.regular(tokens, amounts, keys);
-    }
-
-    function test_RevertWhenRegularEthValueMismatchUnexpectedValue() public {
-        address[] memory tokens = new address[](0);
-        uint256[] memory amounts = new uint256[](0);
-        bytes[] memory keys = new bytes[](0);
-
-        vm.expectRevert(
-            abi.encodeWithSelector(
-                Bridge.EthValueMismatch.selector,
-                uint256(0),
-                uint256(1)
-            )
-        );
-        bridge.regular{value: 1}(tokens, amounts, keys);
     }
 
     function test_RevertWhenRegularAllowanceInsufficient() public {

--- a/contracts/ethereum/test/Bridge.t.sol
+++ b/contracts/ethereum/test/Bridge.t.sol
@@ -56,6 +56,16 @@ contract MockERC20TransferFromFalse is MockERC20 {
     }
 }
 
+contract MockERC20TransferFromRevert is MockERC20 {
+    function transferFrom(
+        address,
+        address,
+        uint256
+    ) external pure override returns (bool) {
+        revert("tf revert");
+    }
+}
+
 contract RevertingReceiver {
     receive() external payable {
         revert("reject");
@@ -364,6 +374,43 @@ contract BridgeTest is Test {
                 uint256(10)
             )
         );
+        vm.prank(nonAdmin);
+        bridge.regular(tokens, amounts, keys);
+    }
+
+    function test_RevertWhenRegularTransferFromReverts() public {
+        MockERC20TransferFromRevert token = new MockERC20TransferFromRevert();
+        token.mint(nonAdmin, 100);
+
+        vm.prank(nonAdmin);
+        assertTrue(token.approve(address(bridge), 10));
+
+        address[] memory tokens = new address[](1);
+        uint256[] memory amounts = new uint256[](1);
+        tokens[0] = address(token);
+        amounts[0] = 10;
+        bytes[] memory keys = new bytes[](0);
+
+        vm.expectRevert(bytes("tf revert"));
+        vm.prank(nonAdmin);
+        bridge.regular(tokens, amounts, keys);
+    }
+
+    function test_RevertWhenRegularKeyPayloadMalformed() public {
+        MockERC20 token = new MockERC20();
+        token.mint(nonAdmin, 100);
+
+        vm.prank(nonAdmin);
+        assertTrue(token.approve(address(bridge), 10));
+
+        address[] memory tokens = new address[](1);
+        uint256[] memory amounts = new uint256[](1);
+        tokens[0] = address(token);
+        amounts[0] = 10;
+        bytes[] memory keys = new bytes[](1);
+        keys[0] = hex"1234";
+
+        vm.expectRevert();
         vm.prank(nonAdmin);
         bridge.regular(tokens, amounts, keys);
     }

--- a/contracts/ethereum/test/Bridge.t.sol
+++ b/contracts/ethereum/test/Bridge.t.sol
@@ -44,6 +44,11 @@ contract BridgeRecoverHarness is Bridge {
 }
 
 contract BridgeTest is Test {
+    // Keep these in sync with action constants in BridgeActions.sol.
+    uint8 constant ACTION_EXECUTE = 0;
+    uint8 constant ACTION_SELF_REPLACE = 1;
+    uint8 constant ACTION_NEW_SET = 2;
+
     event FundsReceived(
         uint64 indexed eventId,
         address indexed sender,
@@ -118,7 +123,7 @@ contract BridgeTest is Test {
 
     function test_ExecuteSignedIncrementsIdsAndEmitsEvent() public {
         bytes memory actionData = abi.encode(
-            uint8(4),
+            ACTION_EXECUTE,
             abi.encode(nonAdmin, 0, bytes(""))
         );
         bytes memory payload = abi.encode(uint64(0), actionData);
@@ -344,7 +349,7 @@ contract BridgeTest is Test {
         uint256 amount = 0.2 ether;
 
         bytes memory actionData = abi.encode(
-            uint8(4),
+            ACTION_EXECUTE,
             abi.encode(recipient, amount, bytes(""))
         );
         bytes memory payload = abi.encode(uint64(0), actionData);
@@ -368,7 +373,7 @@ contract BridgeTest is Test {
 
         bytes memory callData = abi.encodeWithSignature("doesNotExist()");
         bytes memory actionData = abi.encode(
-            uint8(4),
+            ACTION_EXECUTE,
             abi.encode(address(receiver), 0, callData)
         );
         bytes memory payload = abi.encode(uint64(0), actionData);
@@ -392,7 +397,7 @@ contract BridgeTest is Test {
 
     function test_ExecuteSignedSelfReplaceProcessorAction() public {
         bytes memory actionData = abi.encode(
-            uint8(2),
+            ACTION_SELF_REPLACE,
             abi.encode(uint8(1), TEST_VALIDATOR_KEY, TEST_VALIDATOR_KEY_2)
         );
         bytes memory payload = abi.encode(uint64(0), actionData);
@@ -420,9 +425,11 @@ contract BridgeTest is Test {
         assertEq(configNextActionId, 1);
     }
 
-    function test_RevertWhenSelfReplaceProcessorSignedByCurrentProcessor() public {
+    function test_RevertWhenSelfReplaceProcessorSignedByCurrentProcessor()
+        public
+    {
         bytes memory actionData = abi.encode(
-            uint8(2),
+            ACTION_SELF_REPLACE,
             abi.encode(uint8(1), TEST_VALIDATOR_KEY, TEST_VALIDATOR_KEY_2)
         );
         bytes memory payload = abi.encode(uint64(0), actionData);
@@ -447,7 +454,7 @@ contract BridgeTest is Test {
         public
     {
         bytes memory actionData = abi.encode(
-            uint8(2),
+            ACTION_SELF_REPLACE,
             abi.encode(uint8(2), TEST_VALIDATOR_KEY_2, TEST_VALIDATOR_KEY)
         );
         bytes memory payload = abi.encode(uint64(0), actionData);
@@ -478,7 +485,7 @@ contract BridgeTest is Test {
 
     function test_RevertWhenSelfReplaceApproverSignedByOldApprover() public {
         bytes memory actionData = abi.encode(
-            uint8(2),
+            ACTION_SELF_REPLACE,
             abi.encode(uint8(2), TEST_VALIDATOR_KEY_2, TEST_VALIDATOR_KEY)
         );
         bytes memory payload = abi.encode(uint64(0), actionData);
@@ -509,7 +516,7 @@ contract BridgeTest is Test {
         innerApprovals[1] = _signPayload(APPROVER_PRIVATE_KEY, rendered);
 
         bytes memory actionData = abi.encode(
-            uint8(3),
+            ACTION_NEW_SET,
             abi.encode(
                 TEST_VALIDATOR_KEY_2,
                 listeners,
@@ -521,10 +528,7 @@ contract BridgeTest is Test {
             )
         );
         bytes memory payload = abi.encode(uint64(0), actionData);
-        bytes memory processorSig = _signPayload(
-            APPROVER_PRIVATE_KEY,
-            payload
-        );
+        bytes memory processorSig = _signPayload(APPROVER_PRIVATE_KEY, payload);
         bytes[] memory approverSigs = new bytes[](1);
         approverSigs[0] = _signPayload(PROCESSOR_PRIVATE_KEY, payload);
 
@@ -562,7 +566,7 @@ contract BridgeTest is Test {
         innerApprovals[1] = _signPayload(APPROVER_PRIVATE_KEY, rendered);
 
         bytes memory actionData = abi.encode(
-            uint8(3),
+            ACTION_NEW_SET,
             abi.encode(
                 TEST_VALIDATOR_KEY_2,
                 listeners,
@@ -604,7 +608,7 @@ contract BridgeTest is Test {
         innerApprovals[1] = _signPayload(APPROVER_PRIVATE_KEY, rendered);
 
         bytes memory actionData = abi.encode(
-            uint8(3),
+            ACTION_NEW_SET,
             abi.encode(
                 TEST_VALIDATOR_KEY_2,
                 listeners,
@@ -642,7 +646,7 @@ contract BridgeTest is Test {
         innerApprovals[0] = _signPayload(APPROVER_PRIVATE_KEY, rendered);
 
         bytes memory actionData = abi.encode(
-            uint8(3),
+            ACTION_NEW_SET,
             abi.encode(
                 TEST_VALIDATOR_KEY_2,
                 listeners,

--- a/packages/integration-tests/README.md
+++ b/packages/integration-tests/README.md
@@ -18,3 +18,10 @@ dropped using `just drop-db run-tests`
 
 ## Solana-Cosmos bridge
 To run the Solana-Cosmos bridge test run the shell script: `sh solana-bridge-tests.sh bridge_transfer`.
+
+## Ethereum bridge notes
+
+- ERC20 deposit flow is `approve(bridge, amount)` then `regular(token, amount, keys)`.
+- In listener/submitter expectations, Ethereum denoms are normalized as:
+  - `eth` for native ETH
+  - lowercase `0x...` address for ERC20 tokens

--- a/packages/integration-tests/README.md
+++ b/packages/integration-tests/README.md
@@ -21,7 +21,10 @@ To run the Solana-Cosmos bridge test run the shell script: `sh solana-bridge-tes
 
 ## Ethereum bridge notes
 
-- ERC20 deposit flow is `approve(bridge, amount)` then `regular(token, amount, keys)`.
+- Deposit flow uses `regular(tokens, amounts, keys)`:
+  - ERC20: `approve(bridge, amount)` then `regular([token], [amount], keys)` with `msg.value = 0`.
+  - ETH: `regular([address(0)], [amount_wei], keys)` with `msg.value = amount_wei`.
+- Plain ETH transfers to the bridge are unsupported and expected to revert.
 - In listener/submitter expectations, Ethereum denoms are normalized as:
   - `eth` for native ETH
   - lowercase `0x...` address for ERC20 tokens

--- a/packages/integration-tests/README.md
+++ b/packages/integration-tests/README.md
@@ -23,7 +23,8 @@ To run the Solana-Cosmos bridge test run the shell script: `sh solana-bridge-tes
 
 - Deposit flow uses `regular(tokens, amounts, keys)`:
   - ERC20: `approve(bridge, amount)` then `regular([token], [amount], keys)` with `msg.value = 0`.
-  - ETH: `regular([address(0)], [amount_wei], keys)` with `msg.value = amount_wei`.
+  - ETH: `regular([], [], keys)` with `msg.value = amount_wei`.
+- `regular(...)` input funds in calldata are ERC20-only; `token = address(0)` in `tokens` is rejected, ETH amount is in `msg.value`.
 - Plain ETH transfers to the bridge are unsupported and expected to revert.
 - In listener/submitter expectations, Ethereum denoms are normalized as:
   - `eth` for native ETH

--- a/packages/integration-tests/tests/ethereum-bridge.rs
+++ b/packages/integration-tests/tests/ethereum-bridge.rs
@@ -29,6 +29,7 @@ const TEST_ERC20_MINTABLE_ARTIFACT_PATH: &str =
 sol! {
     #[sol(rpc)]
     interface IBridgeIntegration {
+        function regular(address[] tokens, uint256[] amounts, bytes[] keys) external;
         function get_config()
             external
             view
@@ -100,8 +101,17 @@ enum EmptyMessage {
 
 const DUMMY_CODE_VERSION: &str = "ethereum-listener-test-v1";
 const ETH_ASSET_ID: AssetId = AssetId(1);
+const ERC20_ASSET_ID: AssetId = AssetId(2);
 impl EthereumBridgeTestApp {
     fn new(validator: PublicKey, bridge: BridgeContract) -> Self {
+        Self::new_with_optional_erc20(validator, bridge, None)
+    }
+
+    fn new_with_optional_erc20(
+        validator: PublicKey,
+        bridge: BridgeContract,
+        erc20_denom: Option<String>,
+    ) -> Self {
         let mut chains = ConfiguredChains::default();
         let mut assets = BTreeMap::new();
         assets.insert(
@@ -111,6 +121,15 @@ impl EthereumBridgeTestApp {
                 asset_id: ETH_ASSET_ID,
             },
         );
+        if let Some(erc20_denom) = erc20_denom {
+            assets.insert(
+                AssetName(erc20_denom),
+                AssetConfig {
+                    decimals: 18,
+                    asset_id: ERC20_ASSET_ID,
+                },
+            );
+        }
         chains
             .insert_ethereum(EthereumChain::Local, ChainConfig { assets, bridge })
             .unwrap();
@@ -132,6 +151,15 @@ impl EthereumBridgeTestApp {
     }
     fn with_needed_bridge(validator: PublicKey) -> Self {
         Self::new(validator, BridgeContract::NeededEthereumBridge)
+    }
+
+    #[allow(dead_code)]
+    fn with_needed_bridge_and_erc20_asset(validator: PublicKey, erc20_address: Address) -> Self {
+        Self::new_with_optional_erc20(
+            validator,
+            BridgeContract::NeededEthereumBridge,
+            Some(format!("{:#x}", erc20_address)),
+        )
     }
 }
 
@@ -174,6 +202,16 @@ impl KolmeApp for EthereumBridgeTestApp {
 async fn ethereum_listener_ingests_local_deposit() {
     init_logger(true, None);
     TestTasks::start(ethereum_listener_ingests_local_deposit_inner, ()).await;
+}
+
+#[tokio::test]
+async fn ethereum_listener_ingests_local_erc20_regular_deposit() {
+    init_logger(true, None);
+    TestTasks::start(
+        ethereum_listener_ingests_local_erc20_regular_deposit_inner,
+        (),
+    )
+    .await;
 }
 
 #[tokio::test]
@@ -267,6 +305,66 @@ async fn ethereum_listener_ingests_local_deposit_inner(testtasks: TestTasks, ():
 
     tracing::info!(
         "Ethereum deposit ingested by Kolme listener. sender={TEST_ANVIL_ACCOUNT_0_ADDRESS}, tx={tx_hash}, contract={:#x}, amount_wei={test_tx_amount}",
+        deployed.bridge_address
+    );
+}
+
+async fn ethereum_listener_ingests_local_erc20_regular_deposit_inner(testtasks: TestTasks, (): ()) {
+    let provider = anvil_provider().expect("failed to build anvil provider");
+    assert_anvil_identifiers_match(&provider)
+        .await
+        .expect("local anvil setup does not match expected deterministic identifiers");
+
+    let token = deploy_test_erc20_mintable(&provider, TEST_ANVIL_ACCOUNT_0_ADDRESS, "Test", "TST")
+        .await
+        .expect("failed to deploy test ERC20");
+    let deployed = deploy_bridge_with_kolme_with_erc20_asset(&testtasks, token)
+        .await
+        .expect("failed to deploy Ethereum bridge with kolme");
+
+    let deposit_amount: u128 = rand::thread_rng().gen_range(20u128..100u128);
+    mint_test_erc20_mintable(
+        &provider,
+        token,
+        TEST_ANVIL_ACCOUNT_2_ADDRESS,
+        TEST_ANVIL_ACCOUNT_2_ADDRESS
+            .parse()
+            .expect("hardcoded Anvil account 2 address is invalid"),
+        deposit_amount,
+    )
+    .await
+    .expect("failed to mint test ERC20 to depositor");
+    approve_test_erc20_mintable(
+        &provider,
+        token,
+        TEST_ANVIL_ACCOUNT_2_ADDRESS,
+        deployed.bridge_address,
+        deposit_amount,
+    )
+    .await
+    .expect("failed to approve bridge for test ERC20");
+
+    let expected_wallet = Wallet(format!(
+        "{:#x}",
+        TEST_ANVIL_ACCOUNT_2_ADDRESS
+            .parse::<Address>()
+            .expect("hardcoded Anvil account 2 address is invalid")
+    ));
+    let expected_denom = format!("{:#x}", token);
+    send_regular_erc20_and_wait(
+        &deployed.kolme,
+        &provider,
+        &expected_wallet,
+        TEST_ANVIL_ACCOUNT_2_ADDRESS,
+        deployed.bridge_address,
+        token,
+        deposit_amount,
+    )
+    .await
+    .expect("failed to submit regular ERC20 deposit");
+
+    tracing::info!(
+        "Ethereum ERC20 regular() deposit ingested by Kolme listener. sender={TEST_ANVIL_ACCOUNT_2_ADDRESS}, contract={:#x}, token={expected_denom}, amount={deposit_amount}",
         deployed.bridge_address
     );
 }
@@ -436,6 +534,47 @@ async fn deploy_bridge_with_kolme(testtasks: &TestTasks) -> Result<DeployedBridg
     })
 }
 
+async fn deploy_bridge_with_kolme_with_erc20_asset(
+    testtasks: &TestTasks,
+    erc20_address: Address,
+) -> Result<DeployedBridge> {
+    let validator = SecretKey::random();
+    let signer = TEST_ANVIL_ACCOUNT_0_PRIVATE_KEY.parse()?;
+    let kolme = Kolme::new(
+        EthereumBridgeTestApp::with_needed_bridge_and_erc20_asset(
+            validator.public_key(),
+            erc20_address,
+        ),
+        DUMMY_CODE_VERSION,
+        KolmeStore::new_in_memory(),
+    )
+    .await?;
+
+    testtasks.spawn_persistent(Processor::new(kolme.clone(), validator.clone()).run());
+    testtasks.try_spawn_persistent(Approver::new(kolme.clone(), validator.clone()).run());
+    testtasks.try_spawn_persistent(
+        Listener::new(kolme.clone(), validator.clone()).run(ChainName::Ethereum),
+    );
+    testtasks.try_spawn_persistent(Submitter::new_ethereum(kolme.clone(), signer).run());
+
+    let bridge_address = tokio::time::timeout(Duration::from_secs(10), async {
+        loop {
+            if let Some(contract) = deployed_bridge_address(&kolme) {
+                break Ok::<Address, anyhow::Error>(contract.parse()?);
+            }
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        }
+    })
+    .await
+    .context("timed out waiting for Ethereum bridge deployment")??;
+
+    Ok(DeployedBridge {
+        kolme,
+        validator,
+        bridge_address,
+    })
+}
+
 fn iter_block_messages(
     block: &SignedBlock<EmptyMessage>,
 ) -> std::slice::Iter<'_, Message<EmptyMessage>> {
@@ -573,6 +712,98 @@ async fn send_eth_and_wait(
         .context("listener message waiter task failed")??;
 
     Ok(tx_hash)
+}
+
+async fn send_regular_erc20_and_wait(
+    kolme: &Kolme<EthereumBridgeTestApp>,
+    provider: &DynProvider,
+    expected_wallet: &Wallet,
+    from: &str,
+    bridge: Address,
+    token: Address,
+    amount_wei: u128,
+) -> Result<String> {
+    let expected_denom = format!("{:#x}", token);
+    let kolme_for_waiter = kolme.clone();
+    let wallet_for_waiter = expected_wallet.clone();
+    let denom_for_waiter = expected_denom.clone();
+
+    // Start waiting for the event before the tx is sent to avoid race condition
+    let waiter = tokio::spawn(async move {
+        wait_for_expected_listener_message_in_new_blocks_for_fund(
+            &kolme_for_waiter,
+            &wallet_for_waiter,
+            &denom_for_waiter,
+            amount_wei,
+        )
+        .await
+    });
+    tokio::task::yield_now().await;
+
+    let from: Address = from.parse()?;
+    let call = IBridgeIntegration::regularCall {
+        tokens: vec![token],
+        amounts: vec![U256::from(amount_wei)],
+        keys: vec![],
+    };
+    let request = TransactionRequest::default()
+        .with_from(from)
+        .with_to(bridge)
+        .with_input(call.abi_encode());
+    let pending = provider.send_transaction(request).await?;
+    let tx_hash = *pending.tx_hash();
+    let _receipt = pending.get_receipt().await?;
+
+    tokio::time::timeout(Duration::from_secs(10), waiter)
+        .await
+        .context("timed out waiting for specific Ethereum listener message")?
+        .context("listener message waiter task failed")??;
+
+    Ok(format!("{tx_hash:#x}"))
+}
+
+async fn wait_for_expected_listener_message_in_new_blocks_for_fund(
+    kolme: &Kolme<EthereumBridgeTestApp>,
+    expected_wallet: &Wallet,
+    expected_denom: &str,
+    expected_amount_wei: u128,
+) -> Result<()> {
+    let target_chain = ExternalChain::EthereumLocal;
+    let mut next_height = kolme.read().get_next_height();
+
+    loop {
+        let block = kolme.wait_for_block(next_height).await?;
+        let found = iter_block_messages(&block)
+            .filter(|message| {
+                if let Message::Listener {
+                    chain,
+                    event_id: _,
+                    event:
+                        BridgeEvent::Regular {
+                            wallet,
+                            funds,
+                            keys,
+                        },
+                } = message
+                {
+                    *chain == target_chain
+                        && wallet == expected_wallet
+                        && keys.is_empty()
+                        && funds.len() == 1
+                        && funds[0].denom == expected_denom
+                        && funds[0].amount == expected_amount_wei
+                } else {
+                    false
+                }
+            })
+            .count();
+
+        if found == 1 {
+            return Ok(());
+        }
+
+        next_height = next_height.next();
+    }
 }
 
 fn test_erc20_mintable_artifact_path() -> PathBuf {

--- a/packages/integration-tests/tests/ethereum-bridge.rs
+++ b/packages/integration-tests/tests/ethereum-bridge.rs
@@ -2,7 +2,7 @@ use std::{collections::BTreeMap, fs, path::PathBuf, time::Duration};
 
 use alloy::{
     network::TransactionBuilder,
-    primitives::{Address, U256},
+    primitives::{Address, Bytes, U256},
     providers::{DynProvider, Provider, ProviderBuilder},
     rpc::types::eth::TransactionRequest,
     sol,
@@ -29,7 +29,7 @@ const TEST_ERC20_MINTABLE_ARTIFACT_PATH: &str =
 sol! {
     #[sol(rpc)]
     interface IBridgeIntegration {
-        function regular(address[] tokens, uint256[] amounts, bytes[] keys) external;
+        function regular(address[] tokens, uint256[] amounts, bytes[] keys) external payable;
         function get_config()
             external
             view
@@ -54,6 +54,13 @@ sol! {
         function approve(address spender, uint256 amount) external returns (bool);
         function balanceOf(address account) external view returns (uint256);
     }
+}
+
+struct RegularCall {
+    tokens: Vec<Address>,
+    amounts_wei: Vec<u128>,
+    keys: Vec<Bytes>,
+    msg_value_wei: u128,
 }
 
 #[derive(Deserialize)]
@@ -673,15 +680,18 @@ async fn send_eth(
     to: Address,
     amount_wei: u128,
 ) -> Result<String> {
-    let from: Address = from.parse()?;
-    let request = TransactionRequest::default()
-        .with_from(from)
-        .with_to(to)
-        .with_value(U256::from(amount_wei));
-    let pending = provider.send_transaction(request).await?;
-    let tx_hash = *pending.tx_hash();
-    let _receipt = pending.get_receipt().await?;
-    Ok(format!("{tx_hash:#x}"))
+    send_regular(
+        provider,
+        from,
+        to,
+        RegularCall {
+            tokens: vec![Address::ZERO], // 0 address is for ETH
+            amounts_wei: vec![amount_wei],
+            keys: vec![],
+            msg_value_wei: amount_wei,
+        },
+    )
+    .await
 }
 
 async fn send_eth_and_wait(
@@ -723,7 +733,57 @@ async fn send_regular_erc20_and_wait(
     token: Address,
     amount_wei: u128,
 ) -> Result<String> {
-    let expected_denom = format!("{:#x}", token);
+    send_regular_and_wait(
+        kolme,
+        provider,
+        expected_wallet,
+        from,
+        bridge,
+        RegularCall {
+            tokens: vec![token],
+            amounts_wei: vec![amount_wei],
+            keys: vec![],
+            msg_value_wei: 0,
+        },
+    )
+    .await
+}
+
+async fn send_regular_and_wait(
+    kolme: &Kolme<EthereumBridgeTestApp>,
+    provider: &DynProvider,
+    expected_wallet: &Wallet,
+    from: &str,
+    bridge: Address,
+    regular: RegularCall,
+) -> Result<String> {
+    let RegularCall {
+        tokens,
+        amounts_wei,
+        keys,
+        msg_value_wei,
+    } = regular;
+    anyhow::ensure!(
+        tokens.len() == amounts_wei.len(),
+        "send_regular_and_wait tokens/amounts length mismatch: {} vs {}",
+        tokens.len(),
+        amounts_wei.len()
+    );
+
+    // Waiter matches exactly one expected fund entry.
+    // Keep this helper single-asset; batch matching is intentionally out of
+    // scope for these tests.
+    anyhow::ensure!(
+        tokens.len() == 1,
+        "send_regular_and_wait currently expects exactly one token/amount entry"
+    );
+
+    let expected_denom = if tokens[0] == Address::ZERO {
+        "eth".to_owned()
+    } else {
+        format!("{:#x}", tokens[0])
+    };
+    let expected_amount_wei = amounts_wei[0];
     let kolme_for_waiter = kolme.clone();
     let wallet_for_waiter = expected_wallet.clone();
     let denom_for_waiter = expected_denom.clone();
@@ -734,31 +794,66 @@ async fn send_regular_erc20_and_wait(
             &kolme_for_waiter,
             &wallet_for_waiter,
             &denom_for_waiter,
-            amount_wei,
+            expected_amount_wei,
         )
         .await
     });
     tokio::task::yield_now().await;
 
-    let from: Address = from.parse()?;
-    let call = IBridgeIntegration::regularCall {
-        tokens: vec![token],
-        amounts: vec![U256::from(amount_wei)],
-        keys: vec![],
-    };
-    let request = TransactionRequest::default()
-        .with_from(from)
-        .with_to(bridge)
-        .with_input(call.abi_encode());
-    let pending = provider.send_transaction(request).await?;
-    let tx_hash = *pending.tx_hash();
-    let _receipt = pending.get_receipt().await?;
+    let tx_hash = send_regular(
+        provider,
+        from,
+        bridge,
+        RegularCall {
+            tokens,
+            amounts_wei,
+            keys,
+            msg_value_wei,
+        },
+    )
+    .await?;
 
     tokio::time::timeout(Duration::from_secs(10), waiter)
         .await
         .context("timed out waiting for specific Ethereum listener message")?
         .context("listener message waiter task failed")??;
 
+    Ok(tx_hash)
+}
+
+async fn send_regular(
+    provider: &DynProvider,
+    from: &str,
+    bridge: Address,
+    regular: RegularCall,
+) -> Result<String> {
+    let RegularCall {
+        tokens,
+        amounts_wei,
+        keys,
+        msg_value_wei,
+    } = regular;
+    anyhow::ensure!(
+        tokens.len() == amounts_wei.len(),
+        "send_regular tokens/amounts length mismatch: {} vs {}",
+        tokens.len(),
+        amounts_wei.len()
+    );
+
+    let from: Address = from.parse()?;
+    let call = IBridgeIntegration::regularCall {
+        tokens,
+        amounts: amounts_wei.into_iter().map(U256::from).collect(),
+        keys,
+    };
+    let request = TransactionRequest::default()
+        .with_from(from)
+        .with_to(bridge)
+        .with_value(U256::from(msg_value_wei))
+        .with_input(call.abi_encode());
+    let pending = provider.send_transaction(request).await?;
+    let tx_hash = *pending.tx_hash();
+    let _receipt = pending.get_receipt().await?;
     Ok(format!("{tx_hash:#x}"))
 }
 

--- a/packages/integration-tests/tests/ethereum-bridge.rs
+++ b/packages/integration-tests/tests/ethereum-bridge.rs
@@ -685,8 +685,8 @@ async fn send_eth(
         from,
         to,
         RegularCall {
-            tokens: vec![Address::ZERO], // 0 address is for ETH
-            amounts_wei: vec![amount_wei],
+            tokens: vec![],
+            amounts_wei: vec![],
             keys: vec![],
             msg_value_wei: amount_wei,
         },

--- a/packages/integration-tests/tests/ethereum-bridge.rs
+++ b/packages/integration-tests/tests/ethereum-bridge.rs
@@ -1,4 +1,4 @@
-use std::{collections::BTreeMap, time::Duration};
+use std::{collections::BTreeMap, fs, path::PathBuf, time::Duration};
 
 use alloy::{
     network::TransactionBuilder,
@@ -6,10 +6,12 @@ use alloy::{
     providers::{DynProvider, Provider, ProviderBuilder},
     rpc::types::eth::TransactionRequest,
     sol,
+    sol_types::{SolCall, SolConstructor},
 };
 use anyhow::{Context, Result};
 use kolme::*;
 use rand::Rng;
+use serde::Deserialize;
 use testtasks::TestTasks;
 
 // Important note: if same account is used for multiple tests simultaneously in
@@ -21,6 +23,8 @@ const TEST_ANVIL_ACCOUNT_0_PRIVATE_KEY: &str =
 const TEST_ANVIL_ACCOUNT_2_ADDRESS: &str = "0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC";
 
 const TEST_ANVIL_RPC_URL: &str = "http://localhost:8545";
+const TEST_ERC20_MINTABLE_ARTIFACT_PATH: &str =
+    "../../contracts/ethereum/out/TestERC20Mintable.sol/TestERC20Mintable.json";
 
 sol! {
     #[sol(rpc)]
@@ -38,6 +42,27 @@ sol! {
                 uint64 configNextActionId
             );
     }
+
+    contract TestERC20Mintable {
+        constructor(string name_, string symbol_);
+    }
+
+    #[sol(rpc)]
+    interface ITestERC20Mintable {
+        function mint(address to, uint256 amount) external;
+        function approve(address spender, uint256 amount) external returns (bool);
+        function balanceOf(address account) external view returns (uint256);
+    }
+}
+
+#[derive(Deserialize)]
+struct FoundryArtifact {
+    bytecode: ArtifactBytecode,
+}
+
+#[derive(Deserialize)]
+struct ArtifactBytecode {
+    object: String,
 }
 
 #[derive(Clone)]
@@ -548,4 +573,114 @@ async fn send_eth_and_wait(
         .context("listener message waiter task failed")??;
 
     Ok(tx_hash)
+}
+
+fn test_erc20_mintable_artifact_path() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(TEST_ERC20_MINTABLE_ARTIFACT_PATH)
+}
+
+fn load_test_erc20_mintable_create_bytecode() -> Result<Vec<u8>> {
+    let path = test_erc20_mintable_artifact_path();
+    let artifact = fs::read_to_string(&path).with_context(|| {
+        format!(
+            "failed to read TestERC20Mintable artifact at {}. Run `just build-ethereum-contract` first",
+            path.display()
+        )
+    })?;
+
+    let parsed: FoundryArtifact =
+        serde_json::from_str(&artifact).context("failed to parse TestERC20Mintable artifact")?;
+
+    let object = parsed.bytecode.object.trim();
+    anyhow::ensure!(
+        !object.is_empty(),
+        "TestERC20Mintable artifact contains empty bytecode.object"
+    );
+    hex::decode(object.trim_start_matches("0x"))
+        .context("TestERC20Mintable artifact contains invalid hex in bytecode.object")
+}
+
+#[allow(dead_code)]
+async fn deploy_test_erc20_mintable(
+    provider: &DynProvider,
+    from: &str,
+    name: &str,
+    symbol: &str,
+) -> Result<Address> {
+    let from: Address = from.parse()?;
+    let mut initcode = load_test_erc20_mintable_create_bytecode()?;
+    let ctor = TestERC20Mintable::constructorCall::new((name.to_owned(), symbol.to_owned()));
+    initcode.extend_from_slice(&ctor.abi_encode());
+
+    let request = TransactionRequest::default()
+        .with_from(from)
+        .with_deploy_code(initcode);
+    let receipt = provider
+        .send_transaction(request)
+        .await?
+        .get_receipt()
+        .await?;
+    receipt
+        .contract_address
+        .context("ERC20 deployment transaction did not return a contract address")
+}
+
+#[allow(dead_code)]
+async fn mint_test_erc20_mintable(
+    provider: &DynProvider,
+    token: Address,
+    from: &str,
+    to: Address,
+    amount: u128,
+) -> Result<()> {
+    let from: Address = from.parse()?;
+    let call = ITestERC20Mintable::mintCall {
+        to,
+        amount: U256::from(amount),
+    };
+    let request = TransactionRequest::default()
+        .with_from(from)
+        .with_to(token)
+        .with_input(call.abi_encode());
+    let _receipt = provider
+        .send_transaction(request)
+        .await?
+        .get_receipt()
+        .await?;
+    Ok(())
+}
+
+#[allow(dead_code)]
+async fn approve_test_erc20_mintable(
+    provider: &DynProvider,
+    token: Address,
+    from: &str,
+    spender: Address,
+    amount: u128,
+) -> Result<()> {
+    let from: Address = from.parse()?;
+    let call = ITestERC20Mintable::approveCall {
+        spender,
+        amount: U256::from(amount),
+    };
+    let request = TransactionRequest::default()
+        .with_from(from)
+        .with_to(token)
+        .with_input(call.abi_encode());
+    let _receipt = provider
+        .send_transaction(request)
+        .await?
+        .get_receipt()
+        .await?;
+    Ok(())
+}
+
+#[allow(dead_code)]
+async fn balance_of_test_erc20_mintable(
+    provider: DynProvider,
+    token: Address,
+    account: Address,
+) -> Result<U256> {
+    let contract = ITestERC20Mintable::new(token, provider);
+    Ok(contract.balanceOf(account).call().await?)
 }

--- a/packages/kolme/src/core/types.rs
+++ b/packages/kolme/src/core/types.rs
@@ -1998,7 +1998,7 @@ fn serialize_ethereum_payload(
 ) -> Result<String> {
     let action = match action {
         EthereumActionPayload::Transfer { recipient, funds } => {
-            crate::utils::ethereum::encode_transfer_eth_action(recipient, funds)?
+            crate::utils::ethereum::encode_execute_eth_action(recipient, funds)?
         }
         EthereumActionPayload::SelfReplace {
             validator_type,

--- a/packages/kolme/src/core/types.rs
+++ b/packages/kolme/src/core/types.rs
@@ -988,6 +988,13 @@ impl MerkleDeserializeRaw for BlockHeight {
 )]
 pub struct Wallet(pub String);
 
+impl Wallet {
+    #[cfg(feature = "ethereum")]
+    pub fn from_ethereum(address: alloy::primitives::Address) -> Self {
+        Self(crate::utils::ethereum::evm_address_to_string(address))
+    }
+}
+
 impl ToMerkleKey for Wallet {
     fn to_merkle_key(&self) -> MerkleKey {
         self.0.to_merkle_key()
@@ -1640,7 +1647,28 @@ impl ConfiguredChains {
         }
     }
 
+    #[cfg(feature = "ethereum")]
     pub fn insert_ethereum(&mut self, chain: EthereumChain, config: ChainConfig) -> Result<()> {
+        use crate::utils::ethereum::{normalize_ethereum_denom, normalize_evm_address};
+
+        let mut config = config;
+        let mut normalized_assets = BTreeMap::new();
+        for (asset_name, asset_config) in std::mem::take(&mut config.assets) {
+            let normalized_name = normalize_ethereum_denom(&asset_name.0)
+                .with_context(|| format!("Invalid Ethereum asset name: {}", asset_name.0))?;
+            let old = normalized_assets.insert(AssetName(normalized_name.clone()), asset_config);
+            anyhow::ensure!(
+                old.is_none(),
+                "Duplicate Ethereum asset name after normalization: {normalized_name}"
+            );
+        }
+        config.assets = normalized_assets;
+
+        if let BridgeContract::Deployed(address) = &mut config.bridge {
+            *address = normalize_evm_address(address)
+                .with_context(|| format!("Invalid Ethereum bridge contract address: {address}"))?;
+        }
+
         match &config.bridge {
             BridgeContract::NeededCosmosBridge { .. } => {
                 return Err(anyhow::anyhow!(
@@ -1653,25 +1681,13 @@ impl ConfiguredChains {
                 ))
             }
             BridgeContract::NeededEthereumBridge => (),
-            BridgeContract::Deployed(address) => {
-                anyhow::ensure!(
-                    is_valid_evm_address(address),
-                    "Invalid Ethereum bridge contract address: {address}"
-                );
-            }
+            BridgeContract::Deployed(_) => (),
         }
 
         self.0.insert(chain.into(), config);
 
         Ok(())
     }
-}
-
-fn is_valid_evm_address(address: &str) -> bool {
-    let Some(hex) = address.strip_prefix("0x") else {
-        return false;
-    };
-    hex.len() == 40 && hex.chars().all(|c| c.is_ascii_hexdigit())
 }
 
 /// Input and output for a single data load while processing a block.
@@ -1810,6 +1826,8 @@ impl ExecAction {
                     }
                     #[cfg(feature = "ethereum")]
                     ChainName::Ethereum => {
+                        use crate::utils::ethereum::{normalize_ethereum_denom, ETH_NATIVE_DENOM};
+
                         anyhow::ensure!(
                             funds.len() == 1,
                             "Ethereum transfer action supports exactly one fund, got {}",
@@ -1823,15 +1841,19 @@ impl ExecAction {
                             .iter()
                             .find(|(_, config)| config.asset_id == fund.id)
                             .context("Unsupported asset ID")?;
+                        let normalized_asset_name = normalize_ethereum_denom(&asset_name.0)
+                            .with_context(|| {
+                                format!("Invalid Ethereum asset name in config: {}", asset_name.0)
+                            })?;
 
-                        let action = if asset_name.0.eq_ignore_ascii_case("eth") {
+                        let action = if normalized_asset_name == ETH_NATIVE_DENOM {
                             EthereumActionPayload::TransferEth {
                                 recipient: recipient.0.clone(),
                                 amount: fund.amount,
                             }
                         } else {
                             EthereumActionPayload::TransferErc20 {
-                                token: asset_name.0.clone(),
+                                token: normalized_asset_name,
                                 recipient: recipient.0.clone(),
                                 amount: fund.amount,
                             }
@@ -2195,9 +2217,23 @@ impl SolanaClient {
 #[cfg(test)]
 mod tests {
     use super::*;
+    #[cfg(feature = "ethereum")]
+    use alloy::primitives::Address;
     use quickcheck::quickcheck;
     use rust_decimal::dec;
     use std::collections::BTreeMap;
+
+    #[cfg(feature = "ethereum")]
+    #[test]
+    fn wallet_from_ethereum_is_canonical_lowercase_hex() {
+        let address = "0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+            .parse::<Address>()
+            .unwrap();
+        assert_eq!(
+            Wallet::from_ethereum(address),
+            Wallet("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".to_owned())
+        );
+    }
 
     #[test]
     fn increasing_middle_with_difference_of_one() {
@@ -2363,6 +2399,7 @@ mod tests {
         assert_eq!(EthereumChain::Local.default_ws_url(), "ws://localhost:8545");
     }
 
+    #[cfg(feature = "ethereum")]
     #[test]
     fn insert_ethereum_accepts_deployed_evm_address() {
         let mut chains = ConfiguredChains::default();
@@ -2390,6 +2427,7 @@ mod tests {
         assert!(chains.0.contains_key(&ExternalChain::EthereumMainnet));
     }
 
+    #[cfg(feature = "ethereum")]
     #[test]
     fn insert_ethereum_rejects_invalid_bridge_config() {
         let mut chains = ConfiguredChains::default();
@@ -2415,6 +2453,49 @@ mod tests {
         assert!(chains
             .insert_ethereum(EthereumChain::Sepolia, ethereum_kind)
             .is_ok());
+    }
+
+    #[cfg(feature = "ethereum")]
+    #[test]
+    fn insert_ethereum_normalizes_bridge_address_and_asset_names() {
+        let mut chains = ConfiguredChains::default();
+        let mut assets = BTreeMap::new();
+        assets.insert(
+            AssetName("ETH".to_owned()),
+            AssetConfig {
+                decimals: 18,
+                asset_id: AssetId(1),
+            },
+        );
+        assets.insert(
+            AssetName("0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA".to_owned()),
+            AssetConfig {
+                decimals: 6,
+                asset_id: AssetId(2),
+            },
+        );
+        let config = ChainConfig {
+            assets,
+            bridge: BridgeContract::Deployed(
+                "0xBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB".to_owned(),
+            ),
+        };
+
+        chains
+            .insert_ethereum(EthereumChain::Local, config)
+            .unwrap();
+
+        let inserted = chains.0.get(&ExternalChain::EthereumLocal).unwrap();
+        match &inserted.bridge {
+            BridgeContract::Deployed(address) => {
+                assert_eq!(address, "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb");
+            }
+            _ => panic!("unexpected bridge kind"),
+        }
+        assert!(inserted.assets.contains_key(&AssetName("eth".to_owned())));
+        assert!(inserted.assets.contains_key(&AssetName(
+            "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".to_owned()
+        )));
     }
 
     #[cfg(feature = "ethereum")]

--- a/packages/kolme/src/core/types.rs
+++ b/packages/kolme/src/core/types.rs
@@ -2518,6 +2518,82 @@ mod tests {
         assert_eq!(decoded[63], 0x40);
     }
 
+    #[cfg(feature = "ethereum")]
+    #[test]
+    fn to_payload_ethereum_transfer_eth_matches_execute_encoding() {
+        let recipient = Wallet("0x1111111111111111111111111111111111111111".to_owned());
+        let config = ChainConfig {
+            assets: BTreeMap::from([(
+                AssetName("ETH".to_owned()),
+                AssetConfig {
+                    decimals: 18,
+                    asset_id: AssetId(1),
+                },
+            )]),
+            bridge: BridgeContract::NeededEthereumBridge,
+        };
+        let action = ExecAction::Transfer {
+            chain: ExternalChain::EthereumLocal,
+            recipient: recipient.clone(),
+            funds: vec![AssetAmount {
+                id: AssetId(1),
+                amount: 42,
+            }],
+        };
+        let action_id = BridgeActionId(9);
+
+        let payload = action
+            .to_payload(ExternalChain::EthereumLocal, &config, action_id)
+            .unwrap();
+        let decoded =
+            base64::Engine::decode(&base64::engine::general_purpose::STANDARD, payload).unwrap();
+        let expected_action =
+            crate::utils::ethereum::encode_action_transfer_eth(&recipient.0, 42).unwrap();
+        let expected =
+            crate::utils::ethereum::abi_encode_u64_and_bytes(action_id.0, &expected_action);
+        assert_eq!(decoded, expected);
+    }
+
+    #[cfg(feature = "ethereum")]
+    #[test]
+    fn to_payload_ethereum_transfer_erc20_matches_execute_encoding() {
+        let recipient = Wallet("0x1111111111111111111111111111111111111111".to_owned());
+        let config = ChainConfig {
+            assets: BTreeMap::from([(
+                AssetName("0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA".to_owned()),
+                AssetConfig {
+                    decimals: 6,
+                    asset_id: AssetId(1),
+                },
+            )]),
+            bridge: BridgeContract::NeededEthereumBridge,
+        };
+        let action = ExecAction::Transfer {
+            chain: ExternalChain::EthereumLocal,
+            recipient: recipient.clone(),
+            funds: vec![AssetAmount {
+                id: AssetId(1),
+                amount: 7,
+            }],
+        };
+        let action_id = BridgeActionId(3);
+
+        let payload = action
+            .to_payload(ExternalChain::EthereumLocal, &config, action_id)
+            .unwrap();
+        let decoded =
+            base64::Engine::decode(&base64::engine::general_purpose::STANDARD, payload).unwrap();
+        let expected_action = crate::utils::ethereum::encode_action_transfer_erc20(
+            "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            &recipient.0,
+            7,
+        )
+        .unwrap();
+        let expected =
+            crate::utils::ethereum::abi_encode_u64_and_bytes(action_id.0, &expected_action);
+        assert_eq!(decoded, expected);
+    }
+
     #[test]
     fn payload_bytes_to_sign_uses_raw_string_bytes_for_non_ethereum() {
         let action = PendingBridgeAction {

--- a/packages/kolme/src/core/types.rs
+++ b/packages/kolme/src/core/types.rs
@@ -1810,9 +1810,31 @@ impl ExecAction {
                     }
                     #[cfg(feature = "ethereum")]
                     ChainName::Ethereum => {
-                        let action = EthereumActionPayload::Transfer {
-                            recipient: recipient.0.clone(),
-                            funds: funds.clone(),
+                        anyhow::ensure!(
+                            funds.len() == 1,
+                            "Ethereum transfer action supports exactly one fund, got {}",
+                            funds.len()
+                        );
+                        let fund = &funds[0];
+
+                        // TODO: find more efficient way to find asset name
+                        let (asset_name, _) = config
+                            .assets
+                            .iter()
+                            .find(|(_, config)| config.asset_id == fund.id)
+                            .context("Unsupported asset ID")?;
+
+                        let action = if asset_name.0.eq_ignore_ascii_case("eth") {
+                            EthereumActionPayload::TransferEth {
+                                recipient: recipient.0.clone(),
+                                amount: fund.amount,
+                            }
+                        } else {
+                            EthereumActionPayload::TransferErc20 {
+                                token: asset_name.0.clone(),
+                                recipient: recipient.0.clone(),
+                                amount: fund.amount,
+                            }
                         };
                         serialize_ethereum_payload(id, &action)
                     }
@@ -1975,9 +1997,14 @@ impl ExecAction {
 #[cfg(feature = "ethereum")]
 #[derive(Clone)]
 enum EthereumActionPayload {
-    Transfer {
+    TransferEth {
         recipient: String,
-        funds: Vec<AssetAmount>,
+        amount: u128,
+    },
+    TransferErc20 {
+        token: String,
+        recipient: String,
+        amount: u128,
     },
     SelfReplace {
         validator_type: ValidatorType,
@@ -1997,9 +2024,14 @@ fn serialize_ethereum_payload(
     action: &EthereumActionPayload,
 ) -> Result<String> {
     let action = match action {
-        EthereumActionPayload::Transfer { recipient, funds } => {
-            crate::utils::ethereum::encode_execute_eth_action(recipient, funds)?
+        EthereumActionPayload::TransferEth { recipient, amount } => {
+            crate::utils::ethereum::encode_action_transfer_eth(recipient, *amount)?
         }
+        EthereumActionPayload::TransferErc20 {
+            token,
+            recipient,
+            amount,
+        } => crate::utils::ethereum::encode_action_transfer_erc20(token, recipient, *amount)?,
         EthereumActionPayload::SelfReplace {
             validator_type,
             current,
@@ -2388,12 +2420,9 @@ mod tests {
     #[cfg(feature = "ethereum")]
     #[test]
     fn serialize_ethereum_payload_wraps_abi_bytes_in_base64() {
-        let action = EthereumActionPayload::Transfer {
+        let action = EthereumActionPayload::TransferEth {
             recipient: "0x1111111111111111111111111111111111111111".to_owned(),
-            funds: vec![AssetAmount {
-                id: AssetId(7),
-                amount: 42,
-            }],
+            amount: 42,
         };
         let payload = serialize_ethereum_payload(BridgeActionId(9), &action).unwrap();
         let decoded =

--- a/packages/kolme/src/listener/ethereum.rs
+++ b/packages/kolme/src/listener/ethereum.rs
@@ -36,7 +36,7 @@ impl EthereumListenerMode {
 }
 
 sol! {
-    event FundsReceived(uint64 indexed eventId, address indexed sender, address[] tokens, uint256[] amounts);
+    event FundsReceived(uint64 indexed eventId, address indexed sender, address[] tokens, uint256[] amounts, bytes[] keys);
 
     #[sol(rpc)]
     contract Bridge {
@@ -101,6 +101,7 @@ impl EthereumBridgeEvent {
                 sender,
                 tokens,
                 amounts,
+                keys,
                 ..
             }) => {
                 anyhow::ensure!(
@@ -128,7 +129,10 @@ impl EthereumBridgeEvent {
                 BridgeEvent::Regular {
                     wallet: Wallet(format!("{:#x}", sender)),
                     funds,
-                    keys: vec![],
+                    keys: keys
+                        .iter()
+                        .map(|key| PublicKey::from_bytes(key.as_ref()))
+                        .collect::<Result<Vec<_>, _>>()?,
                 }
             }
         };
@@ -554,10 +558,10 @@ mod tests {
     #[test]
     fn funds_received_topic_hash_matches_constant() {
         // To recalculate signature hash:
-        // cast keccak "FundsReceived(uint64,address,address[],uint256[])"
+        // cast keccak "FundsReceived(uint64,address,address[],uint256[],bytes[])"
         // (in contracts/ethereum)
         const FUNDS_RECEIVED_EVENT_TOPIC0_HEX: &str =
-            "0xa64b0227b96084eb93ea9d6a70b367bd844217ac4d2bce15ee7537196d68503b";
+            "0x02bb338ef0fcb89993f4087b28532775e53951c8025a81666d399e7263389a6c";
         let expected = FUNDS_RECEIVED_EVENT_TOPIC0_HEX.parse::<B256>().unwrap();
         assert_eq!(FundsReceived::SIGNATURE_HASH, expected);
     }
@@ -582,11 +586,13 @@ mod tests {
         sender_topic[12..].copy_from_slice(sender.as_slice());
         let amounts = vec![U256::from(42u64), U256::from(7u64)];
         let tokens = vec![token_a, token_b];
+        let keys = vec![Bytes::from(vec![0x02; 33])];
         let event = FundsReceived {
             eventId: event_id,
             sender,
             tokens: tokens.clone(),
             amounts: amounts.clone(),
+            keys: keys.clone(),
         };
 
         let log_data = LogData::new(
@@ -612,6 +618,7 @@ mod tests {
         assert_eq!(decoded.sender, sender);
         assert_eq!(decoded.tokens, tokens);
         assert_eq!(decoded.amounts, amounts);
+        assert_eq!(decoded.keys, keys);
     }
 
     #[test]

--- a/packages/kolme/src/listener/ethereum.rs
+++ b/packages/kolme/src/listener/ethereum.rs
@@ -36,7 +36,7 @@ impl EthereumListenerMode {
 }
 
 sol! {
-    event FundsReceived(uint64 indexed eventId, address indexed sender, uint256 amount);
+    event FundsReceived(uint64 indexed eventId, address indexed sender, address[] tokens, uint256[] amounts);
 
     #[sol(rpc)]
     contract Bridge {
@@ -97,14 +97,40 @@ impl EthereumBridgeEvent {
         event_id: BridgeEventId,
     ) -> Result<Message<AppMessage>> {
         let event = match self {
-            Self::FundsReceived(FundsReceived { sender, amount, .. }) => BridgeEvent::Regular {
-                wallet: Wallet(format!("{:#x}", sender)),
-                funds: vec![BridgedAssetAmount {
-                    denom: ETH_NATIVE_DENOM.to_owned(),
-                    amount: u256_to_u128(*amount)?,
-                }],
-                keys: vec![],
-            },
+            Self::FundsReceived(FundsReceived {
+                sender,
+                tokens,
+                amounts,
+                ..
+            }) => {
+                anyhow::ensure!(
+                    tokens.len() == amounts.len(),
+                    "Ethereum FundsReceived malformed payload: tokens length {} != amounts length {}",
+                    tokens.len(),
+                    amounts.len()
+                );
+                let funds = tokens
+                    .iter()
+                    .zip(amounts.iter())
+                    .map(|(token, amount)| {
+                        let denom = if *token == Address::ZERO {
+                            ETH_NATIVE_DENOM.to_owned()
+                        } else {
+                            format!("{:#x}", token)
+                        };
+                        Ok(BridgedAssetAmount {
+                            denom,
+                            amount: u256_to_u128(*amount)?,
+                        })
+                    })
+                    .collect::<Result<Vec<_>>>()?;
+
+                BridgeEvent::Regular {
+                    wallet: Wallet(format!("{:#x}", sender)),
+                    funds,
+                    keys: vec![],
+                }
+            }
         };
 
         Ok(Message::Listener {
@@ -527,8 +553,11 @@ mod tests {
 
     #[test]
     fn funds_received_topic_hash_matches_constant() {
+        // To recalculate signature hash:
+        // cast keccak "FundsReceived(uint64,address,address[],uint256[])"
+        // (in contracts/ethereum)
         const FUNDS_RECEIVED_EVENT_TOPIC0_HEX: &str =
-            "0x4ade6a296f99f38f840a2a880cc9a27cec9ee56ce8d56cd80d3350e3419ed44c";
+            "0xa64b0227b96084eb93ea9d6a70b367bd844217ac4d2bce15ee7537196d68503b";
         let expected = FUNDS_RECEIVED_EVENT_TOPIC0_HEX.parse::<B256>().unwrap();
         assert_eq!(FundsReceived::SIGNATURE_HASH, expected);
     }
@@ -540,6 +569,10 @@ mod tests {
         let sender = "0x1111111111111111111111111111111111111111"
             .parse::<Address>()
             .unwrap();
+        let token_a = "0x2222222222222222222222222222222222222222"
+            .parse::<Address>()
+            .unwrap();
+        let token_b = Address::ZERO;
 
         let event_id = 7u64;
         let mut event_id_topic = [0u8; 32];
@@ -547,10 +580,14 @@ mod tests {
 
         let mut sender_topic = [0u8; 32];
         sender_topic[12..].copy_from_slice(sender.as_slice());
-
-        let amount = U256::from(42u64);
-        let mut data = [0u8; 32];
-        data[0..32].copy_from_slice(&amount.to_be_bytes::<32>());
+        let amounts = vec![U256::from(42u64), U256::from(7u64)];
+        let tokens = vec![token_a, token_b];
+        let event = FundsReceived {
+            eventId: event_id,
+            sender,
+            tokens: tokens.clone(),
+            amounts: amounts.clone(),
+        };
 
         let log_data = LogData::new(
             vec![
@@ -558,7 +595,7 @@ mod tests {
                 B256::from(event_id_topic),
                 B256::from(sender_topic),
             ],
-            Bytes::copy_from_slice(&data),
+            Bytes::from(event.encode_data()),
         )
         .unwrap();
         let log = Log {
@@ -573,7 +610,8 @@ mod tests {
 
         assert_eq!(decoded.eventId, event_id);
         assert_eq!(decoded.sender, sender);
-        assert_eq!(decoded.amount, amount);
+        assert_eq!(decoded.tokens, tokens);
+        assert_eq!(decoded.amounts, amounts);
     }
 
     #[test]

--- a/packages/kolme/src/listener/ethereum.rs
+++ b/packages/kolme/src/listener/ethereum.rs
@@ -637,6 +637,62 @@ mod tests {
     }
 
     #[test]
+    fn to_kolme_message_maps_eth_and_erc20_denoms() {
+        let event = EthereumBridgeEvent::FundsReceived(FundsReceived {
+            eventId: 9,
+            sender: "0x1111111111111111111111111111111111111111"
+                .parse::<Address>()
+                .unwrap(),
+            tokens: vec![
+                "0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+                    .parse::<Address>()
+                    .unwrap(),
+                Address::ZERO,
+            ],
+            amounts: vec![U256::from(5u64), U256::from(7u64)],
+            keys: vec![],
+        });
+
+        let message = event
+            .to_kolme_message::<()>(ExternalChain::EthereumLocal, BridgeEventId(9))
+            .unwrap();
+        let Message::Listener {
+            event: BridgeEvent::Regular { wallet, funds, .. },
+            ..
+        } = message
+        else {
+            panic!("unexpected message kind");
+        };
+
+        assert_eq!(
+            wallet,
+            Wallet("0x1111111111111111111111111111111111111111".to_owned())
+        );
+        assert_eq!(funds.len(), 2);
+        assert_eq!(funds[0].denom, "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+        assert_eq!(funds[0].amount, 5);
+        assert_eq!(funds[1].denom, "eth");
+        assert_eq!(funds[1].amount, 7);
+    }
+
+    #[test]
+    fn to_kolme_message_rejects_mismatched_token_and_amount_lengths() {
+        let event = EthereumBridgeEvent::FundsReceived(FundsReceived {
+            eventId: 1,
+            sender: "0x1111111111111111111111111111111111111111"
+                .parse::<Address>()
+                .unwrap(),
+            tokens: vec![Address::ZERO],
+            amounts: vec![],
+            keys: vec![],
+        });
+
+        assert!(event
+            .to_kolme_message::<()>(ExternalChain::EthereumLocal, BridgeEventId(1))
+            .is_err());
+    }
+
+    #[test]
     fn u256_to_u128_rejects_overflow() {
         assert!(u256_to_u128(U256::from(u128::MAX) + U256::from(1)).is_err());
     }

--- a/packages/kolme/src/listener/ethereum.rs
+++ b/packages/kolme/src/listener/ethereum.rs
@@ -1,3 +1,4 @@
+use crate::utils::ethereum::token_address_to_denom;
 use crate::*;
 use alloy::{
     contract::{ContractInstance, Interface},
@@ -12,7 +13,6 @@ use futures_util::StreamExt;
 
 use super::get_next_bridge_event_id;
 
-const ETH_NATIVE_DENOM: &str = "eth";
 const POLL_INTERVAL: tokio::time::Duration = tokio::time::Duration::from_secs(1);
 const WS_RETRY_INTERVAL: tokio::time::Duration = tokio::time::Duration::from_secs(30);
 
@@ -114,20 +114,15 @@ impl EthereumBridgeEvent {
                     .iter()
                     .zip(amounts.iter())
                     .map(|(token, amount)| {
-                        let denom = if *token == Address::ZERO {
-                            ETH_NATIVE_DENOM.to_owned()
-                        } else {
-                            format!("{:#x}", token)
-                        };
                         Ok(BridgedAssetAmount {
-                            denom,
+                            denom: token_address_to_denom(*token),
                             amount: u256_to_u128(*amount)?,
                         })
                     })
                     .collect::<Result<Vec<_>>>()?;
 
                 BridgeEvent::Regular {
-                    wallet: Wallet(format!("{:#x}", sender)),
+                    wallet: Wallet::from_ethereum(*sender),
                     funds,
                     keys: keys
                         .iter()

--- a/packages/kolme/src/utils/ethereum.rs
+++ b/packages/kolme/src/utils/ethereum.rs
@@ -12,18 +12,11 @@ use alloy::{
 use crate::SignatureWithRecovery;
 use crate::{AssetAmount, PublicKey, ValidatorSet, ValidatorType};
 
-pub const ACTION_TRANSFER_ETH: u8 = 0;
-pub const ACTION_TRANSFER_ERC20: u8 = 1;
 pub const ACTION_SELF_REPLACE: u8 = 2;
 pub const ACTION_NEW_SET: u8 = 3;
 pub const ACTION_EXECUTE: u8 = 4;
 
 sol! {
-    struct TransferEthAction {
-        address recipient;
-        uint256 amount;
-    }
-
     struct ExecuteAction {
         address target;
         uint256 value;
@@ -112,7 +105,7 @@ pub fn abi_encode_u8_and_bytes(value: u8, data: &[u8]) -> Vec<u8> {
     encoded
 }
 
-pub fn encode_transfer_eth_action(
+pub fn encode_execute_eth_action(
     recipient: &str,
     funds: &[AssetAmount],
 ) -> anyhow::Result<Vec<u8>> {
@@ -123,13 +116,9 @@ pub fn encode_transfer_eth_action(
     );
     let fund = funds[0].clone();
     let recipient = Address::from_str(recipient)?;
-    let transfer = TransferEthAction {
-        recipient,
-        amount: U256::from(fund.amount),
-    };
     let action = ExecuteAction {
-        target: transfer.recipient,
-        value: transfer.amount,
+        target: recipient,
+        value: U256::from(fund.amount),
         data: vec![].into(),
     };
     Ok(abi_encode_u8_and_bytes(ACTION_EXECUTE, &action.abi_encode()))

--- a/packages/kolme/src/utils/ethereum.rs
+++ b/packages/kolme/src/utils/ethereum.rs
@@ -12,9 +12,10 @@ use alloy::{
 use crate::SignatureWithRecovery;
 use crate::{AssetAmount, PublicKey, ValidatorSet, ValidatorType};
 
-pub const ACTION_SELF_REPLACE: u8 = 2;
-pub const ACTION_NEW_SET: u8 = 3;
-pub const ACTION_EXECUTE: u8 = 4;
+// Keep these in sync with action constants in contracts/ethereum/src/BridgeActions.sol.
+pub const ACTION_EXECUTE: u8 = 0;
+pub const ACTION_SELF_REPLACE: u8 = 1;
+pub const ACTION_NEW_SET: u8 = 2;
 
 sol! {
     struct ExecuteAction {

--- a/packages/kolme/src/utils/ethereum.rs
+++ b/packages/kolme/src/utils/ethereum.rs
@@ -16,6 +16,7 @@ use crate::{PublicKey, ValidatorSet, ValidatorType};
 pub const ACTION_EXECUTE: u8 = 0;
 pub const ACTION_SELF_REPLACE: u8 = 1;
 pub const ACTION_NEW_SET: u8 = 2;
+pub const ETH_NATIVE_DENOM: &str = "eth";
 
 sol! {
     struct ExecuteAction {
@@ -63,6 +64,32 @@ fn encode_execute_action(target: Address, value: U256, data: Vec<u8>) -> Vec<u8>
     // Encode as tuple directly to match abi.decode(data, (address,uint256,bytes)).
     let action = (target, value, Bytes::from(data)).abi_encode_params();
     abi_encode_u8_and_bytes(ACTION_EXECUTE, &action)
+}
+
+pub fn evm_address_to_string(address: Address) -> String {
+    format!("{:#x}", address)
+}
+
+pub fn normalize_evm_address(address: &str) -> anyhow::Result<String> {
+    let address = Address::from_str(address)?;
+    Ok(evm_address_to_string(address))
+}
+
+/// `denom` could be "eth" (case-insensitive) or a EVM address.
+/// Will be canonicalized (lowercase "eth" or "0x...")
+pub fn normalize_ethereum_denom(denom: &str) -> anyhow::Result<String> {
+    if denom.eq_ignore_ascii_case(ETH_NATIVE_DENOM) {
+        return Ok(ETH_NATIVE_DENOM.to_owned());
+    }
+    normalize_evm_address(denom)
+}
+
+pub fn token_address_to_denom(token: Address) -> String {
+    if token == Address::ZERO {
+        ETH_NATIVE_DENOM.to_owned()
+    } else {
+        evm_address_to_string(token)
+    }
 }
 
 /// Build ACTION_EXECUTE payload for ETH transfers
@@ -161,7 +188,8 @@ pub fn encode_new_set_action(
 mod tests {
     use super::{
         abi_encode_u64_and_bytes, abi_encode_u8_and_bytes, encode_action_transfer_erc20,
-        encode_action_transfer_eth, ACTION_EXECUTE,
+        encode_action_transfer_eth, normalize_ethereum_denom, normalize_evm_address,
+        ACTION_EXECUTE, ETH_NATIVE_DENOM,
     };
     use alloy::primitives::{Address, U256};
     use std::str::FromStr;
@@ -265,5 +293,19 @@ mod tests {
         );
         assert_eq!(value, U256::from(0u128));
         assert_eq!(&data[0..4], &[0xa9, 0x05, 0x9c, 0xbb]); // transfer(address,uint256)
+    }
+
+    #[test]
+    fn normalize_ethereum_denom_canonicalizes_eth_and_evm_addresses() {
+        assert_eq!(normalize_ethereum_denom("ETH").unwrap(), ETH_NATIVE_DENOM);
+        assert_eq!(
+            normalize_ethereum_denom("0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA").unwrap(),
+            "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        );
+    }
+
+    #[test]
+    fn normalize_evm_address_rejects_non_address() {
+        assert!(normalize_evm_address("eth").is_err());
     }
 }

--- a/packages/kolme/src/utils/ethereum.rs
+++ b/packages/kolme/src/utils/ethereum.rs
@@ -4,13 +4,13 @@
 use std::str::FromStr;
 
 use alloy::{
-    primitives::{Address, U256},
+    primitives::{Address, Bytes, U256},
     sol,
-    sol_types::SolValue,
+    sol_types::{SolCall, SolValue},
 };
 
 use crate::SignatureWithRecovery;
-use crate::{AssetAmount, PublicKey, ValidatorSet, ValidatorType};
+use crate::{PublicKey, ValidatorSet, ValidatorType};
 
 // Keep these in sync with action constants in contracts/ethereum/src/BridgeActions.sol.
 pub const ACTION_EXECUTE: u8 = 0;
@@ -39,90 +39,55 @@ sol! {
         bytes rendered;
         bytes[] approvals;
     }
+
+    interface IERC20 {
+        function transfer(address recipient, uint256 amount) external returns (bool);
+    }
 }
 
 /// ABI-encode execute_signed() payload `(uint64 action_id, bytes action_data)` according
 /// to Solidity ABI rules.
 pub fn abi_encode_u64_and_bytes(value: u64, data: &[u8]) -> Vec<u8> {
-    const WORD_SIZE: usize = 32;
-
-    let mut encoded =
-        Vec::with_capacity(WORD_SIZE * 3 + data.len().div_ceil(WORD_SIZE) * WORD_SIZE);
-
-    // head[0] = uint64
-    let mut word = [0u8; WORD_SIZE];
-    word[WORD_SIZE - 8..].copy_from_slice(&value.to_be_bytes());
-    encoded.extend_from_slice(&word);
-
-    // head[1] = offset to dynamic bytes argument
-    word.fill(0);
-    word[WORD_SIZE - 1] = 0x40;
-    encoded.extend_from_slice(&word);
-
-    // tail[0] = bytes length
-    word.fill(0);
-    word[WORD_SIZE - 8..].copy_from_slice(&(data.len() as u64).to_be_bytes());
-    encoded.extend_from_slice(&word);
-
-    // tail[1..] = bytes data + right padding to 32-byte boundary
-    encoded.extend_from_slice(data);
-    let padding = (WORD_SIZE - (data.len() % WORD_SIZE)) % WORD_SIZE;
-    if padding > 0 {
-        encoded.resize(encoded.len() + padding, 0);
-    }
-
-    encoded
+    (value, Bytes::copy_from_slice(data)).abi_encode_params()
 }
 
 /// ABI-encode _executeAction() payload `(uint8, bytes)` in bridge contract
 pub fn abi_encode_u8_and_bytes(value: u8, data: &[u8]) -> Vec<u8> {
-    const WORD_SIZE: usize = 32;
-
-    let mut encoded =
-        Vec::with_capacity(WORD_SIZE * 3 + data.len().div_ceil(WORD_SIZE) * WORD_SIZE);
-
-    // head[0] = uint8
-    let mut word = [0u8; WORD_SIZE];
-    word[WORD_SIZE - 1] = value;
-    encoded.extend_from_slice(&word);
-
-    // head[1] = offset to dynamic bytes argument
-    word.fill(0);
-    word[WORD_SIZE - 1] = 0x40;
-    encoded.extend_from_slice(&word);
-
-    // tail[0] = bytes length
-    word.fill(0);
-    word[WORD_SIZE - 8..].copy_from_slice(&(data.len() as u64).to_be_bytes());
-    encoded.extend_from_slice(&word);
-
-    // tail[1..] = bytes data + right padding to 32-byte boundary
-    encoded.extend_from_slice(data);
-    let padding = (WORD_SIZE - (data.len() % WORD_SIZE)) % WORD_SIZE;
-    if padding > 0 {
-        encoded.resize(encoded.len() + padding, 0);
-    }
-
-    encoded
+    // In ABI head encoding, uint8 and uint256 both occupy one 32-byte word;
+    // for values 0..=255 the byte layout is identical.
+    (U256::from(value), Bytes::copy_from_slice(data)).abi_encode_params()
 }
 
-pub fn encode_execute_eth_action(
-    recipient: &str,
-    funds: &[AssetAmount],
-) -> anyhow::Result<Vec<u8>> {
-    anyhow::ensure!(
-        funds.len() == 1,
-        "Ethereum transfer action supports exactly one fund, got {}",
-        funds.len()
-    );
-    let fund = funds[0].clone();
+fn encode_execute_action(target: Address, value: U256, data: Vec<u8>) -> Vec<u8> {
+    // Solidity decodes execute data as tuple: (address,uint256,bytes).
+    // Encode as tuple directly to match abi.decode(data, (address,uint256,bytes)).
+    let action = (target, value, Bytes::from(data)).abi_encode_params();
+    abi_encode_u8_and_bytes(ACTION_EXECUTE, &action)
+}
+
+/// Build ACTION_EXECUTE payload for ETH transfers
+pub fn encode_action_transfer_eth(recipient: &str, amount: u128) -> anyhow::Result<Vec<u8>> {
     let recipient = Address::from_str(recipient)?;
-    let action = ExecuteAction {
-        target: recipient,
-        value: U256::from(fund.amount),
-        data: vec![].into(),
+    Ok(encode_execute_action(recipient, U256::from(amount), vec![]))
+}
+
+/// Build ACTION_EXECUTE payload for ERC20(custom tokens) transfers
+pub fn encode_action_transfer_erc20(
+    token: &str,
+    recipient: &str,
+    amount: u128,
+) -> anyhow::Result<Vec<u8>> {
+    let token = Address::from_str(token)?;
+    let recipient = Address::from_str(recipient)?;
+    let transfer_call = IERC20::transferCall {
+        recipient,
+        amount: U256::from(amount),
     };
-    Ok(abi_encode_u8_and_bytes(ACTION_EXECUTE, &action.abi_encode()))
+    Ok(encode_execute_action(
+        token,
+        U256::ZERO,
+        transfer_call.abi_encode(),
+    ))
 }
 
 pub fn encode_self_replace_action(
@@ -194,7 +159,31 @@ pub fn encode_new_set_action(
 
 #[cfg(test)]
 mod tests {
-    use super::{abi_encode_u64_and_bytes, abi_encode_u8_and_bytes};
+    use super::{
+        abi_encode_u64_and_bytes, abi_encode_u8_and_bytes, encode_action_transfer_erc20,
+        encode_action_transfer_eth, ACTION_EXECUTE,
+    };
+    use alloy::primitives::{Address, U256};
+    use std::str::FromStr;
+
+    fn decode_execute_action_contract_abi(action: &[u8]) -> (Address, U256, Vec<u8>) {
+        assert!(action.len() >= 128, "action payload too short");
+
+        let target = Address::from_slice(&action[12..32]);
+        let value = U256::from_be_slice(&action[32..64]);
+        let data_offset = U256::from_be_slice(&action[64..96]).to::<usize>();
+        assert_eq!(data_offset, 96, "unexpected execute calldata offset");
+
+        let data_len = U256::from_be_slice(&action[96..128]).to::<usize>();
+        let data_start = 128usize;
+        let data_end = data_start + data_len;
+        assert!(
+            action.len() >= data_end,
+            "execute calldata shorter than declared length"
+        );
+
+        (target, value, action[data_start..data_end].to_vec())
+    }
 
     #[test]
     fn abi_encode_u64_and_bytes_matches_expected_layout() {
@@ -238,5 +227,43 @@ mod tests {
         // bytes data + right-padding
         assert_eq!(&encoded[96..99], b"abc");
         assert!(encoded[99..128].iter().all(|x| *x == 0));
+    }
+
+    #[test]
+    fn encode_action_transfer_eth_uses_empty_calldata_and_amount_as_value() {
+        let payload =
+            encode_action_transfer_eth("0x1111111111111111111111111111111111111111", 42).unwrap();
+
+        assert_eq!(payload[31], ACTION_EXECUTE);
+        let action_bytes_len = u64::from_be_bytes(payload[88..96].try_into().unwrap()) as usize;
+        let (target, value, data) =
+            decode_execute_action_contract_abi(&payload[96..96 + action_bytes_len]);
+        assert_eq!(
+            target,
+            Address::from_str("0x1111111111111111111111111111111111111111").unwrap()
+        );
+        assert_eq!(value, U256::from(42u128));
+        assert!(data.is_empty());
+    }
+
+    #[test]
+    fn encode_action_transfer_erc20_uses_transfer_calldata() {
+        let payload = encode_action_transfer_erc20(
+            "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+            7,
+        )
+        .unwrap();
+
+        assert_eq!(payload[31], ACTION_EXECUTE);
+        let action_bytes_len = u64::from_be_bytes(payload[88..96].try_into().unwrap()) as usize;
+        let (target, value, data) =
+            decode_execute_action_contract_abi(&payload[96..96 + action_bytes_len]);
+        assert_eq!(
+            target,
+            Address::from_str("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa").unwrap()
+        );
+        assert_eq!(value, U256::from(0u128));
+        assert_eq!(&data[0..4], &[0xa9, 0x05, 0x9c, 0xbb]); // transfer(address,uint256)
     }
 }

--- a/packages/kolme/src/utils/ethereum.rs
+++ b/packages/kolme/src/utils/ethereum.rs
@@ -16,11 +16,18 @@ pub const ACTION_TRANSFER_ETH: u8 = 0;
 pub const ACTION_TRANSFER_ERC20: u8 = 1;
 pub const ACTION_SELF_REPLACE: u8 = 2;
 pub const ACTION_NEW_SET: u8 = 3;
+pub const ACTION_EXECUTE: u8 = 4;
 
 sol! {
     struct TransferEthAction {
         address recipient;
         uint256 amount;
+    }
+
+    struct ExecuteAction {
+        address target;
+        uint256 value;
+        bytes data;
     }
 
     struct SelfReplaceAction {
@@ -116,14 +123,16 @@ pub fn encode_transfer_eth_action(
     );
     let fund = funds[0].clone();
     let recipient = Address::from_str(recipient)?;
-    let action = TransferEthAction {
+    let transfer = TransferEthAction {
         recipient,
         amount: U256::from(fund.amount),
     };
-    Ok(abi_encode_u8_and_bytes(
-        ACTION_TRANSFER_ETH,
-        &action.abi_encode(),
-    ))
+    let action = ExecuteAction {
+        target: transfer.recipient,
+        value: transfer.amount,
+        data: vec![].into(),
+    };
+    Ok(abi_encode_u8_and_bytes(ACTION_EXECUTE, &action.abi_encode()))
 }
 
 pub fn encode_self_replace_action(


### PR DESCRIPTION
- replace ACTION_TRANSFER_ETH and ACTION_TRANSFER_ERC20 actions in contract with ACTION_EXECUTE
- rearrange ACTION_* constants to have gapless ordering (while we have the window to do it)
- make `execute_signed()` atomic with `ReentrancyGuard` from `openzeppelin-contracts`
- implement `regular()` contract endpoint as the only deposit entry for both ETH and ERC20 (ETH uses token =  `address(0)`)
- remove `receive()` payable entry point completely - plain ETH transfers will be now hard-reverted
- modify `FundsReceived` contract event - make it capable to include multiple transfers, also add `tokens` and `keys` data
- refactor: use `SolValue::abi_encode_params()` instead of manually fiddling with bytes
- test coverage, including E2E test that deploys tiny ERC20 test contract and receives tokens from it
  -  update ETH sending in integration tests to use `regular()` entry point
- update docs
- pin base container version in Ethereum E2E container's `Dockerfile`, because `ubuntu:24.04` is updated very often, we don't need it updated that much