### PR TITLE
Quick Model doc

### DIFF
--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -3,6 +3,7 @@
 [Introduction](intro.md)
 
 - [Technical Overview](technical/overview.md)
+  - [Quick Model](technical/quick-model.md)
   - [Core Chain Mechanics](technical/core-mechanics.md)
   - [Triadic Security Model](technical/triadic-security.md)
   - [External Data Handling](technical/external-data.md)

--- a/docs/src/intro.md
+++ b/docs/src/intro.md
@@ -8,6 +8,8 @@ Kolme is a Rust-powered blockchain framework that empowers developers to build f
 
 This document provides an overview of Kolme’s architecture, real-world use cases, and key benefits, serving as your entry point to building the future of decentralized technology.
 
+For a concise system-level model (also suitable as context for AI assistants), see [Quick Model](technical/quick-model.md).
+
 Want to see the code? Check out [the Kolme GitHub repo](https://github.com/fpco/kolme).
 
 ## Why Kolme?

--- a/docs/src/technical/quick-model.md
+++ b/docs/src/technical/quick-model.md
@@ -1,0 +1,17 @@
+# Quick Model
+
+High-level model; implementation details may vary by chain/component.
+
+Kolme is an appchain framework: each app runs on its own public chain, with app logic in deterministic Rust.
+
+- Transactions are gossiped through the network mempool, and the processor validates signature + nonce, executes, and emits 1 transaction per block on demand. Ordering is processor policy (typically arrival-order + nonce validity), not a global fee-market auction.
+- The processor is a single logical block-producer role (HA cluster with operator-controlled failover; only one active signer at a time), while other nodes can re-execute blocks to verify correctness.
+- Block production is processor-authoritative for liveness; safety is enforced operationally via quorum governance (e.g., key rotation/replacement), not autonomous fork competition.
+- State is split into framework state (balances, nonces, validator sets, proposals, chain version) and app state; both are hash-committed in blocks and updated atomically per transaction.
+- Security roles: listeners (observe external-chain bridge events), processor (executes/blocks), approvers (authorize outbound bridge actions), submitters (best-effort relayers that broadcast approved actions externally).
+- Listeners and approvers are quorum multisig sets using aggregated individual signatures (not threshold crypto), with chain-specific finality handling (e.g., Solana finalized commitment); there is no generic configurable N-block confirmation-depth rule in current code.
+- Inbound bridge flow: external event -> listener quorum confirmation -> processor ingests and executes on Kolme.
+- Outbound bridge flow: Kolme emits ordered bridge actions -> approver quorum signs -> submitter relays to external chain.
+- Admin/security changes require 2 of 3 validator groups (processor, listeners, approvers).
+- Core app execution is independent of external-chain liveness; outages mainly delay deposits/withdrawals and bridge settlement.
+- Trust model (high level): safety depends on quorum honesty in listener/approver groups plus operator control of processor key lifecycle.


### PR DESCRIPTION
- Add a `quick-model.md` doc - a short technical description of Kolme architecture, intended for faster onboarding and as context for AI assistants. This document was generated by AI, prompted to give a technical description of Kolme architecture, keeping it clear, concise and aligned to the actual code.
- Link the doc in the Summary, at the beginning of Technical Overview section
- Add a respective paragraph to the first section of the Intro

