### PR TITLE
[KOL-91] Implement Ethereum reorg mitigation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,8 +90,6 @@ jobs:
         run: just anvil
       - name: Ethereum contract tests
         run: just cargo-contract-tests-ethereum
-      - name: Ethereum subscription-only contract tests
-        run: just cargo-contract-tests-ethereum-sub
 
   solana-contract:
     name: Solana Tests

--- a/docs/src/technical/external-chain-resilience.md
+++ b/docs/src/technical/external-chain-resilience.md
@@ -15,7 +15,7 @@ Kolme minimizes reliance on external blockchains, ensuring applications remain o
 - **Validation**:
   - Listeners and approvers validate bridge events (e.g., deposits, withdrawals) as transactions, ensuring security without external chain dependency, per [Triadic Security Model](triadic-security.md).
   - For Ethereum, polling is the authoritative ingestion path; WebSocket subscription is used as an in-memory hint source for scan optimization, not as an ingestion mode.
-  - Ethereum polling applies `confirmation_depth` from chain config: `UseDefault` (Ethereum default), `Disabled` (no confirmation bound), or `Value(n)` (explicit depth).
+  - Ethereum polling applies `confirmation_depth` from chain config: `None` means no confirmation bound; `Some(n)` means explicit depth of `n` blocks.
 
 ## Bridge Contracts
 

--- a/docs/src/technical/external-chain-resilience.md
+++ b/docs/src/technical/external-chain-resilience.md
@@ -14,6 +14,8 @@ Kolme minimizes reliance on external blockchains, ensuring applications remain o
   - Supports multichain apps by maintaining functionality during chain migrations (e.g., adding Cosmos), per [Node Synchronization](node-sync.md).
 - **Validation**:
   - Listeners and approvers validate bridge events (e.g., deposits, withdrawals) as transactions, ensuring security without external chain dependency, per [Triadic Security Model](triadic-security.md).
+  - For Ethereum, polling is the authoritative ingestion path; WebSocket subscription is used as an in-memory hint source for scan optimization, not as an ingestion mode.
+  - Ethereum polling applies `confirmation_depth` from chain config: `UseDefault` (Ethereum default), `Disabled` (no confirmation bound), or `Value(n)` (explicit depth).
 
 ## Bridge Contracts
 

--- a/docs/src/technical/quick-model.md
+++ b/docs/src/technical/quick-model.md
@@ -9,7 +9,7 @@ Kolme is an appchain framework: each app runs on its own public chain, with app 
 - Block production is processor-authoritative for liveness; safety is enforced operationally via quorum governance (e.g., key rotation/replacement), not autonomous fork competition.
 - State is split into framework state (balances, nonces, validator sets, proposals, chain version) and app state; both are hash-committed in blocks and updated atomically per transaction.
 - Security roles: listeners (observe external-chain bridge events), processor (executes/blocks), approvers (authorize outbound bridge actions), submitters (best-effort relayers that broadcast approved actions externally).
-- Listeners and approvers are quorum multisig sets using aggregated individual signatures (not threshold crypto), with chain-specific finality handling (e.g., Solana finalized commitment); there is no generic configurable N-block confirmation-depth rule in current code.
+- Listeners and approvers are quorum multisig sets using aggregated individual signatures (not threshold crypto), with chain-specific finality handling (e.g., Solana finalized commitment).
 - Inbound bridge flow: external event -> listener quorum confirmation -> processor ingests and executes on Kolme.
 - Outbound bridge flow: Kolme emits ordered bridge actions -> approver quorum signs -> submitter relays to external chain.
 - Admin/security changes require 2 of 3 validator groups (processor, listeners, approvers).

--- a/justfile
+++ b/justfile
@@ -92,11 +92,7 @@ cargo-contract-tests:
 
 cargo-contract-tests-ethereum:
     just build-ethereum-contract
-    cargo test -p integration-tests --test ethereum-bridge -- --test-threads=1 --skip subscription_only_listener_works
-
-cargo-contract-tests-ethereum-sub:
-    just build-ethereum-contract
-    KOLME_ETH_LISTENER_MODE=subscription-only cargo test -p integration-tests --test ethereum-bridge subscription_only_listener_works -- --test-threads=1
+    cargo test -p integration-tests --test ethereum-bridge -- --test-threads=1
 
 # Stress test
 stress-test:

--- a/packages/examples/cosmos-bridge/src/lib.rs
+++ b/packages/examples/cosmos-bridge/src/lib.rs
@@ -92,6 +92,7 @@ impl Default for CosmosBridgeApp {
                     bridge: BridgeContract::NeededCosmosBridge {
                         code_id: OSMOSIS_TESTNET_CODE_ID,
                     },
+                    confirmation_depth: None,
                 },
             )
             .unwrap();
@@ -113,6 +114,7 @@ impl Default for CosmosBridgeApp {
                     bridge: BridgeContract::NeededCosmosBridge {
                         code_id: NEUTRON_TESTNET_CODE_ID,
                     },
+                    confirmation_depth: None,
                 },
             )
             .unwrap();

--- a/packages/examples/cosmos-bridge/src/lib.rs
+++ b/packages/examples/cosmos-bridge/src/lib.rs
@@ -92,7 +92,7 @@ impl Default for CosmosBridgeApp {
                     bridge: BridgeContract::NeededCosmosBridge {
                         code_id: OSMOSIS_TESTNET_CODE_ID,
                     },
-                    confirmation_depth: None,
+                    confirmation_depth: ConfirmationDepth::Disabled,
                 },
             )
             .unwrap();
@@ -114,7 +114,7 @@ impl Default for CosmosBridgeApp {
                     bridge: BridgeContract::NeededCosmosBridge {
                         code_id: NEUTRON_TESTNET_CODE_ID,
                     },
-                    confirmation_depth: None,
+                    confirmation_depth: ConfirmationDepth::Disabled,
                 },
             )
             .unwrap();

--- a/packages/examples/cosmos-bridge/src/lib.rs
+++ b/packages/examples/cosmos-bridge/src/lib.rs
@@ -92,7 +92,7 @@ impl Default for CosmosBridgeApp {
                     bridge: BridgeContract::NeededCosmosBridge {
                         code_id: OSMOSIS_TESTNET_CODE_ID,
                     },
-                    confirmation_depth: ConfirmationDepth::Disabled,
+                    confirmation_depth: None,
                 },
             )
             .unwrap();
@@ -114,7 +114,7 @@ impl Default for CosmosBridgeApp {
                     bridge: BridgeContract::NeededCosmosBridge {
                         code_id: NEUTRON_TESTNET_CODE_ID,
                     },
-                    confirmation_depth: ConfirmationDepth::Disabled,
+                    confirmation_depth: None,
                 },
             )
             .unwrap();

--- a/packages/examples/six-sigma/src/lib.rs
+++ b/packages/examples/six-sigma/src/lib.rs
@@ -92,6 +92,7 @@ impl SixSigmaApp {
                     bridge: BridgeContract::NeededCosmosBridge {
                         code_id: LOCALOSMOSIS_CODE_ID,
                     },
+                    confirmation_depth: None,
                 },
             )
             .unwrap();
@@ -123,6 +124,7 @@ impl SixSigmaApp {
                     bridge: BridgeContract::NeededSolanaBridge {
                         program_id: "7Y2ftN9nSf4ubzRDiUvcENMeV4S695JEFpYtqdt836pW".into(),
                     },
+                    confirmation_depth: None,
                 },
             )
             .unwrap();
@@ -152,6 +154,7 @@ impl SixSigmaApp {
             .insert_pass_through(ChainConfig {
                 assets,
                 bridge: BridgeContract::Deployed("12345".to_string()),
+                confirmation_depth: None,
             })
             .unwrap();
 

--- a/packages/examples/six-sigma/src/lib.rs
+++ b/packages/examples/six-sigma/src/lib.rs
@@ -92,7 +92,7 @@ impl SixSigmaApp {
                     bridge: BridgeContract::NeededCosmosBridge {
                         code_id: LOCALOSMOSIS_CODE_ID,
                     },
-                    confirmation_depth: ConfirmationDepth::Disabled,
+                    confirmation_depth: None,
                 },
             )
             .unwrap();
@@ -124,7 +124,7 @@ impl SixSigmaApp {
                     bridge: BridgeContract::NeededSolanaBridge {
                         program_id: "7Y2ftN9nSf4ubzRDiUvcENMeV4S695JEFpYtqdt836pW".into(),
                     },
-                    confirmation_depth: ConfirmationDepth::Disabled,
+                    confirmation_depth: None,
                 },
             )
             .unwrap();
@@ -154,7 +154,7 @@ impl SixSigmaApp {
             .insert_pass_through(ChainConfig {
                 assets,
                 bridge: BridgeContract::Deployed("12345".to_string()),
-                confirmation_depth: ConfirmationDepth::Disabled,
+                confirmation_depth: None,
             })
             .unwrap();
 

--- a/packages/examples/six-sigma/src/lib.rs
+++ b/packages/examples/six-sigma/src/lib.rs
@@ -92,7 +92,7 @@ impl SixSigmaApp {
                     bridge: BridgeContract::NeededCosmosBridge {
                         code_id: LOCALOSMOSIS_CODE_ID,
                     },
-                    confirmation_depth: None,
+                    confirmation_depth: ConfirmationDepth::Disabled,
                 },
             )
             .unwrap();
@@ -124,7 +124,7 @@ impl SixSigmaApp {
                     bridge: BridgeContract::NeededSolanaBridge {
                         program_id: "7Y2ftN9nSf4ubzRDiUvcENMeV4S695JEFpYtqdt836pW".into(),
                     },
-                    confirmation_depth: None,
+                    confirmation_depth: ConfirmationDepth::Disabled,
                 },
             )
             .unwrap();
@@ -154,7 +154,7 @@ impl SixSigmaApp {
             .insert_pass_through(ChainConfig {
                 assets,
                 bridge: BridgeContract::Deployed("12345".to_string()),
-                confirmation_depth: None,
+                confirmation_depth: ConfirmationDepth::Disabled,
             })
             .unwrap();
 

--- a/packages/examples/solana-cosmos-bridge/src/lib.rs
+++ b/packages/examples/solana-cosmos-bridge/src/lib.rs
@@ -79,7 +79,7 @@ impl Default for SolanaCosmosBridgeApp {
                     bridge: BridgeContract::NeededCosmosBridge {
                         code_id: OSMOSIS_CODE_ID,
                     },
-                    confirmation_depth: ConfirmationDepth::Disabled,
+                    confirmation_depth: None,
                 },
             )
             .unwrap();
@@ -101,7 +101,7 @@ impl Default for SolanaCosmosBridgeApp {
                     bridge: BridgeContract::NeededSolanaBridge {
                         program_id: "7Y2ftN9nSf4ubzRDiUvcENMeV4S695JEFpYtqdt836pW".into(),
                     },
-                    confirmation_depth: ConfirmationDepth::Disabled,
+                    confirmation_depth: None,
                 },
             )
             .unwrap();

--- a/packages/examples/solana-cosmos-bridge/src/lib.rs
+++ b/packages/examples/solana-cosmos-bridge/src/lib.rs
@@ -79,7 +79,7 @@ impl Default for SolanaCosmosBridgeApp {
                     bridge: BridgeContract::NeededCosmosBridge {
                         code_id: OSMOSIS_CODE_ID,
                     },
-                    confirmation_depth: None,
+                    confirmation_depth: ConfirmationDepth::Disabled,
                 },
             )
             .unwrap();
@@ -101,7 +101,7 @@ impl Default for SolanaCosmosBridgeApp {
                     bridge: BridgeContract::NeededSolanaBridge {
                         program_id: "7Y2ftN9nSf4ubzRDiUvcENMeV4S695JEFpYtqdt836pW".into(),
                     },
-                    confirmation_depth: None,
+                    confirmation_depth: ConfirmationDepth::Disabled,
                 },
             )
             .unwrap();

--- a/packages/examples/solana-cosmos-bridge/src/lib.rs
+++ b/packages/examples/solana-cosmos-bridge/src/lib.rs
@@ -79,6 +79,7 @@ impl Default for SolanaCosmosBridgeApp {
                     bridge: BridgeContract::NeededCosmosBridge {
                         code_id: OSMOSIS_CODE_ID,
                     },
+                    confirmation_depth: None,
                 },
             )
             .unwrap();
@@ -100,6 +101,7 @@ impl Default for SolanaCosmosBridgeApp {
                     bridge: BridgeContract::NeededSolanaBridge {
                         program_id: "7Y2ftN9nSf4ubzRDiUvcENMeV4S695JEFpYtqdt836pW".into(),
                     },
+                    confirmation_depth: None,
                 },
             )
             .unwrap();

--- a/packages/integration-tests/tests/balances.rs
+++ b/packages/integration-tests/tests/balances.rs
@@ -63,6 +63,7 @@ impl SampleKolmeApp {
                 ChainConfig {
                     assets,
                     bridge: BridgeContract::NeededCosmosBridge { code_id },
+                    confirmation_depth: None,
                 },
             )
             .unwrap();

--- a/packages/integration-tests/tests/balances.rs
+++ b/packages/integration-tests/tests/balances.rs
@@ -63,7 +63,7 @@ impl SampleKolmeApp {
                 ChainConfig {
                     assets,
                     bridge: BridgeContract::NeededCosmosBridge { code_id },
-                    confirmation_depth: None,
+                    confirmation_depth: ConfirmationDepth::Disabled,
                 },
             )
             .unwrap();

--- a/packages/integration-tests/tests/balances.rs
+++ b/packages/integration-tests/tests/balances.rs
@@ -63,7 +63,7 @@ impl SampleKolmeApp {
                 ChainConfig {
                     assets,
                     bridge: BridgeContract::NeededCosmosBridge { code_id },
-                    confirmation_depth: ConfirmationDepth::Disabled,
+                    confirmation_depth: None,
                 },
             )
             .unwrap();

--- a/packages/integration-tests/tests/cosmos-migration.rs
+++ b/packages/integration-tests/tests/cosmos-migration.rs
@@ -51,7 +51,7 @@ impl SampleKolmeApp {
                 ChainConfig {
                     assets: BTreeMap::new(),
                     bridge: BridgeContract::NeededCosmosBridge { code_id },
-                    confirmation_depth: ConfirmationDepth::Disabled,
+                    confirmation_depth: None,
                 },
             )
             .unwrap();

--- a/packages/integration-tests/tests/cosmos-migration.rs
+++ b/packages/integration-tests/tests/cosmos-migration.rs
@@ -51,7 +51,7 @@ impl SampleKolmeApp {
                 ChainConfig {
                     assets: BTreeMap::new(),
                     bridge: BridgeContract::NeededCosmosBridge { code_id },
-                    confirmation_depth: None,
+                    confirmation_depth: ConfirmationDepth::Disabled,
                 },
             )
             .unwrap();

--- a/packages/integration-tests/tests/cosmos-migration.rs
+++ b/packages/integration-tests/tests/cosmos-migration.rs
@@ -51,6 +51,7 @@ impl SampleKolmeApp {
                 ChainConfig {
                     assets: BTreeMap::new(),
                     bridge: BridgeContract::NeededCosmosBridge { code_id },
+                    confirmation_depth: None,
                 },
             )
             .unwrap();

--- a/packages/integration-tests/tests/ethereum-bridge.rs
+++ b/packages/integration-tests/tests/ethereum-bridge.rs
@@ -111,12 +111,7 @@ const ETH_ASSET_ID: AssetId = AssetId(1);
 const ERC20_ASSET_ID: AssetId = AssetId(2);
 impl EthereumBridgeTestApp {
     fn new(validator: PublicKey, bridge: BridgeContract) -> Self {
-        Self::new_with_optional_erc20_and_confirmation_depth(
-            validator,
-            bridge,
-            None,
-            ConfirmationDepth::Disabled,
-        )
+        Self::new_with_optional_erc20_and_confirmation_depth(validator, bridge, None, None)
     }
 
     fn new_with_optional_erc20(
@@ -124,19 +119,14 @@ impl EthereumBridgeTestApp {
         bridge: BridgeContract,
         erc20_denom: Option<String>,
     ) -> Self {
-        Self::new_with_optional_erc20_and_confirmation_depth(
-            validator,
-            bridge,
-            erc20_denom,
-            ConfirmationDepth::Disabled,
-        )
+        Self::new_with_optional_erc20_and_confirmation_depth(validator, bridge, erc20_denom, None)
     }
 
     fn new_with_optional_erc20_and_confirmation_depth(
         validator: PublicKey,
         bridge: BridgeContract,
         erc20_denom: Option<String>,
-        confirmation_depth: ConfirmationDepth,
+        confirmation_depth: Option<u64>,
     ) -> Self {
         let mut chains = ConfiguredChains::default();
         let mut assets = BTreeMap::new();
@@ -188,7 +178,7 @@ impl EthereumBridgeTestApp {
 
     fn with_needed_bridge_and_confirmation_depth(
         validator: PublicKey,
-        confirmation_depth: ConfirmationDepth,
+        confirmation_depth: Option<u64>,
     ) -> Self {
         Self::new_with_optional_erc20_and_confirmation_depth(
             validator,
@@ -357,10 +347,9 @@ async fn ethereum_listener_ingests_local_deposit_with_confirmation_depth_1_inner
     testtasks: TestTasks,
     (): (),
 ) {
-    let deployed =
-        deploy_bridge_with_kolme_with_confirmation_depth(&testtasks, ConfirmationDepth::Value(1))
-            .await
-            .expect("failed to deploy Ethereum bridge with kolme");
+    let deployed = deploy_bridge_with_kolme_with_confirmation_depth(&testtasks, Some(1))
+        .await
+        .expect("failed to deploy Ethereum bridge with kolme");
     let test_tx_amount: u128 = rand::thread_rng().gen_range(20u128..100u128);
     let provider = anvil_provider().expect("failed to build anvil provider");
     assert_anvil_identifiers_match(&provider)
@@ -648,7 +637,7 @@ async fn deploy_bridge_with_kolme(testtasks: &TestTasks) -> Result<DeployedBridg
 
 async fn deploy_bridge_with_kolme_with_confirmation_depth(
     testtasks: &TestTasks,
-    confirmation_depth: ConfirmationDepth,
+    confirmation_depth: Option<u64>,
 ) -> Result<DeployedBridge> {
     let validator = SecretKey::random();
     let signer = TEST_ANVIL_ACCOUNT_0_PRIVATE_KEY.parse()?;

--- a/packages/integration-tests/tests/ethereum-bridge.rs
+++ b/packages/integration-tests/tests/ethereum-bridge.rs
@@ -231,17 +231,6 @@ async fn ethereum_listener_ingests_local_erc20_regular_deposit() {
 }
 
 #[tokio::test]
-async fn subscription_only_listener_works() {
-    init_logger(true, None);
-    assert_eq!(
-        std::env::var("KOLME_ETH_LISTENER_MODE").ok().as_deref(),
-        Some("subscription-only"),
-        "KOLME_ETH_LISTENER_MODE must be set to \"subscription-only\" for this test",
-    );
-    TestTasks::start(ethereum_listener_ingests_local_deposit_inner, ()).await;
-}
-
-#[tokio::test]
 async fn ethereum_bridge_get_config_is_readable() {
     init_logger(true, None);
     TestTasks::start(ethereum_bridge_get_config_is_readable_inner, ()).await;

--- a/packages/integration-tests/tests/ethereum-bridge.rs
+++ b/packages/integration-tests/tests/ethereum-bridge.rs
@@ -138,7 +138,16 @@ impl EthereumBridgeTestApp {
             );
         }
         chains
-            .insert_ethereum(EthereumChain::Local, ChainConfig { assets, bridge })
+            .insert_ethereum(
+                EthereumChain::Local,
+                ChainConfig {
+                    assets,
+                    bridge,
+                    confirmation_depth: Some(
+                        kolme::utils::ethereum::DEFAULT_ETHEREUM_CONFIRMATION_DEPTH,
+                    ),
+                },
+            )
             .unwrap();
 
         Self {

--- a/packages/integration-tests/tests/ethereum-bridge.rs
+++ b/packages/integration-tests/tests/ethereum-bridge.rs
@@ -111,13 +111,32 @@ const ETH_ASSET_ID: AssetId = AssetId(1);
 const ERC20_ASSET_ID: AssetId = AssetId(2);
 impl EthereumBridgeTestApp {
     fn new(validator: PublicKey, bridge: BridgeContract) -> Self {
-        Self::new_with_optional_erc20(validator, bridge, None)
+        Self::new_with_optional_erc20_and_confirmation_depth(
+            validator,
+            bridge,
+            None,
+            ConfirmationDepth::Disabled,
+        )
     }
 
     fn new_with_optional_erc20(
         validator: PublicKey,
         bridge: BridgeContract,
         erc20_denom: Option<String>,
+    ) -> Self {
+        Self::new_with_optional_erc20_and_confirmation_depth(
+            validator,
+            bridge,
+            erc20_denom,
+            ConfirmationDepth::Disabled,
+        )
+    }
+
+    fn new_with_optional_erc20_and_confirmation_depth(
+        validator: PublicKey,
+        bridge: BridgeContract,
+        erc20_denom: Option<String>,
+        confirmation_depth: ConfirmationDepth,
     ) -> Self {
         let mut chains = ConfiguredChains::default();
         let mut assets = BTreeMap::new();
@@ -143,7 +162,7 @@ impl EthereumBridgeTestApp {
                 ChainConfig {
                     assets,
                     bridge,
-                    confirmation_depth: ConfirmationDepth::Disabled,
+                    confirmation_depth,
                 },
             )
             .unwrap();
@@ -165,6 +184,18 @@ impl EthereumBridgeTestApp {
     }
     fn with_needed_bridge(validator: PublicKey) -> Self {
         Self::new(validator, BridgeContract::NeededEthereumBridge)
+    }
+
+    fn with_needed_bridge_and_confirmation_depth(
+        validator: PublicKey,
+        confirmation_depth: ConfirmationDepth,
+    ) -> Self {
+        Self::new_with_optional_erc20_and_confirmation_depth(
+            validator,
+            BridgeContract::NeededEthereumBridge,
+            None,
+            confirmation_depth,
+        )
     }
 
     #[allow(dead_code)]
@@ -216,6 +247,16 @@ impl KolmeApp for EthereumBridgeTestApp {
 async fn ethereum_listener_ingests_local_deposit() {
     init_logger(true, None);
     TestTasks::start(ethereum_listener_ingests_local_deposit_inner, ()).await;
+}
+
+#[tokio::test]
+async fn ethereum_listener_ingests_local_deposit_with_confirmation_depth_1() {
+    init_logger(true, None);
+    TestTasks::start(
+        ethereum_listener_ingests_local_deposit_with_confirmation_depth_1_inner,
+        (),
+    )
+    .await;
 }
 
 #[tokio::test]
@@ -308,6 +349,74 @@ async fn ethereum_listener_ingests_local_deposit_inner(testtasks: TestTasks, ():
 
     tracing::info!(
         "Ethereum deposit ingested by Kolme listener. sender={TEST_ANVIL_ACCOUNT_0_ADDRESS}, tx={tx_hash}, contract={:#x}, amount_wei={test_tx_amount}",
+        deployed.bridge_address
+    );
+}
+
+async fn ethereum_listener_ingests_local_deposit_with_confirmation_depth_1_inner(
+    testtasks: TestTasks,
+    (): (),
+) {
+    let deployed =
+        deploy_bridge_with_kolme_with_confirmation_depth(&testtasks, ConfirmationDepth::Value(1))
+            .await
+            .expect("failed to deploy Ethereum bridge with kolme");
+    let test_tx_amount: u128 = rand::thread_rng().gen_range(20u128..100u128);
+    let provider = anvil_provider().expect("failed to build anvil provider");
+    assert_anvil_identifiers_match(&provider)
+        .await
+        .expect("local anvil setup does not match expected deterministic identifiers");
+
+    let expected_wallet = Wallet(format!(
+        "{:#x}",
+        TEST_ANVIL_ACCOUNT_0_ADDRESS
+            .parse::<Address>()
+            .expect("hardcoded Anvil account 0 address is invalid")
+    ));
+
+    let kolme_for_waiter = deployed.kolme.clone();
+    let wallet_for_waiter = expected_wallet.clone();
+    let waiter = tokio::spawn(async move {
+        wait_for_expected_listener_message_in_new_blocks(
+            &kolme_for_waiter,
+            &wallet_for_waiter,
+            test_tx_amount,
+        )
+        .await
+    });
+    tokio::task::yield_now().await;
+
+    let tx_hash = send_eth(
+        &provider,
+        TEST_ANVIL_ACCOUNT_0_ADDRESS,
+        deployed.bridge_address,
+        test_tx_amount,
+    )
+    .await
+    .expect("failed to send ETH to bridge contract");
+
+    tokio::time::sleep(Duration::from_millis(1500)).await;
+    assert!(
+        !waiter.is_finished(),
+        "depth=1 listener ingested event before it had one additional confirmation block"
+    );
+
+    // Mine one extra block so depth=1 confirms the deposit block.
+    let mine_to: Address = TEST_ANVIL_ACCOUNT_2_ADDRESS
+        .parse()
+        .expect("hardcoded Anvil account 2 address is invalid");
+    let _mine_tx_hash = send_eth(&provider, TEST_ANVIL_ACCOUNT_0_ADDRESS, mine_to, 1)
+        .await
+        .expect("failed to mine follow-up block for confirmation depth");
+
+    tokio::time::timeout(Duration::from_secs(10), waiter)
+        .await
+        .expect("timed out waiting for depth=1 Ethereum listener ingestion")
+        .expect("listener message waiter task failed")
+        .expect("failed waiting for listener message");
+
+    tracing::info!(
+        "Ethereum deposit ingested by Kolme listener with confirmation_depth=1. sender={TEST_ANVIL_ACCOUNT_0_ADDRESS}, tx={tx_hash}, contract={:#x}, amount_wei={test_tx_amount}",
         deployed.bridge_address
     );
 }
@@ -507,6 +616,47 @@ async fn deploy_bridge_with_kolme(testtasks: &TestTasks) -> Result<DeployedBridg
     let signer = TEST_ANVIL_ACCOUNT_0_PRIVATE_KEY.parse()?;
     let kolme = Kolme::new(
         EthereumBridgeTestApp::with_needed_bridge(validator.public_key()),
+        DUMMY_CODE_VERSION,
+        KolmeStore::new_in_memory(),
+    )
+    .await?;
+
+    testtasks.spawn_persistent(Processor::new(kolme.clone(), validator.clone()).run());
+    testtasks.try_spawn_persistent(Approver::new(kolme.clone(), validator.clone()).run());
+    testtasks.try_spawn_persistent(
+        Listener::new(kolme.clone(), validator.clone()).run(ChainName::Ethereum),
+    );
+    testtasks.try_spawn_persistent(Submitter::new_ethereum(kolme.clone(), signer).run());
+
+    let bridge_address = tokio::time::timeout(Duration::from_secs(10), async {
+        loop {
+            if let Some(contract) = deployed_bridge_address(&kolme) {
+                break Ok::<Address, anyhow::Error>(contract.parse()?);
+            }
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        }
+    })
+    .await
+    .context("timed out waiting for Ethereum bridge deployment")??;
+
+    Ok(DeployedBridge {
+        kolme,
+        validator,
+        bridge_address,
+    })
+}
+
+async fn deploy_bridge_with_kolme_with_confirmation_depth(
+    testtasks: &TestTasks,
+    confirmation_depth: ConfirmationDepth,
+) -> Result<DeployedBridge> {
+    let validator = SecretKey::random();
+    let signer = TEST_ANVIL_ACCOUNT_0_PRIVATE_KEY.parse()?;
+    let kolme = Kolme::new(
+        EthereumBridgeTestApp::with_needed_bridge_and_confirmation_depth(
+            validator.public_key(),
+            confirmation_depth,
+        ),
         DUMMY_CODE_VERSION,
         KolmeStore::new_in_memory(),
     )

--- a/packages/integration-tests/tests/ethereum-bridge.rs
+++ b/packages/integration-tests/tests/ethereum-bridge.rs
@@ -143,9 +143,7 @@ impl EthereumBridgeTestApp {
                 ChainConfig {
                     assets,
                     bridge,
-                    confirmation_depth: Some(
-                        kolme::utils::ethereum::DEFAULT_ETHEREUM_CONFIRMATION_DEPTH,
-                    ),
+                    confirmation_depth: ConfirmationDepth::Disabled,
                 },
             )
             .unwrap();

--- a/packages/integration-tests/tests/key-rotation.rs
+++ b/packages/integration-tests/tests/key-rotation.rs
@@ -72,6 +72,7 @@ impl SampleKolmeApp {
                     bridge: BridgeContract::NeededCosmosBridge {
                         code_id: bridge_code_id,
                     },
+                    confirmation_depth: None,
                 },
             )
             .unwrap();
@@ -108,6 +109,7 @@ impl SampleKolmeApp {
                     bridge: BridgeContract::NeededSolanaBridge {
                         program_id: BRIDGE_PUBKEY.to_string(),
                     },
+                    confirmation_depth: None,
                 },
             )
             .unwrap();

--- a/packages/integration-tests/tests/key-rotation.rs
+++ b/packages/integration-tests/tests/key-rotation.rs
@@ -72,7 +72,7 @@ impl SampleKolmeApp {
                     bridge: BridgeContract::NeededCosmosBridge {
                         code_id: bridge_code_id,
                     },
-                    confirmation_depth: None,
+                    confirmation_depth: ConfirmationDepth::Disabled,
                 },
             )
             .unwrap();
@@ -109,7 +109,7 @@ impl SampleKolmeApp {
                     bridge: BridgeContract::NeededSolanaBridge {
                         program_id: BRIDGE_PUBKEY.to_string(),
                     },
-                    confirmation_depth: None,
+                    confirmation_depth: ConfirmationDepth::Disabled,
                 },
             )
             .unwrap();

--- a/packages/integration-tests/tests/key-rotation.rs
+++ b/packages/integration-tests/tests/key-rotation.rs
@@ -72,7 +72,7 @@ impl SampleKolmeApp {
                     bridge: BridgeContract::NeededCosmosBridge {
                         code_id: bridge_code_id,
                     },
-                    confirmation_depth: ConfirmationDepth::Disabled,
+                    confirmation_depth: None,
                 },
             )
             .unwrap();
@@ -109,7 +109,7 @@ impl SampleKolmeApp {
                     bridge: BridgeContract::NeededSolanaBridge {
                         program_id: BRIDGE_PUBKEY.to_string(),
                     },
-                    confirmation_depth: ConfirmationDepth::Disabled,
+                    confirmation_depth: None,
                 },
             )
             .unwrap();

--- a/packages/integration-tests/tests/solana-migration.rs
+++ b/packages/integration-tests/tests/solana-migration.rs
@@ -51,7 +51,7 @@ impl SampleKolmeApp {
                     bridge: BridgeContract::NeededSolanaBridge {
                         program_id: BRIDGE_PUBKEY.to_string(),
                     },
-                    confirmation_depth: None,
+                    confirmation_depth: ConfirmationDepth::Disabled,
                 },
             )
             .unwrap();

--- a/packages/integration-tests/tests/solana-migration.rs
+++ b/packages/integration-tests/tests/solana-migration.rs
@@ -51,7 +51,7 @@ impl SampleKolmeApp {
                     bridge: BridgeContract::NeededSolanaBridge {
                         program_id: BRIDGE_PUBKEY.to_string(),
                     },
-                    confirmation_depth: ConfirmationDepth::Disabled,
+                    confirmation_depth: None,
                 },
             )
             .unwrap();

--- a/packages/integration-tests/tests/solana-migration.rs
+++ b/packages/integration-tests/tests/solana-migration.rs
@@ -51,6 +51,7 @@ impl SampleKolmeApp {
                     bridge: BridgeContract::NeededSolanaBridge {
                         program_id: BRIDGE_PUBKEY.to_string(),
                     },
+                    confirmation_depth: None,
                 },
             )
             .unwrap();

--- a/packages/integration-tests/tests/validate_from.rs
+++ b/packages/integration-tests/tests/validate_from.rs
@@ -63,6 +63,7 @@ impl SampleKolmeApp {
                 ChainConfig {
                     assets,
                     bridge: BridgeContract::NeededCosmosBridge { code_id },
+                    confirmation_depth: None,
                 },
             )
             .unwrap();

--- a/packages/integration-tests/tests/validate_from.rs
+++ b/packages/integration-tests/tests/validate_from.rs
@@ -63,7 +63,7 @@ impl SampleKolmeApp {
                 ChainConfig {
                     assets,
                     bridge: BridgeContract::NeededCosmosBridge { code_id },
-                    confirmation_depth: None,
+                    confirmation_depth: ConfirmationDepth::Disabled,
                 },
             )
             .unwrap();

--- a/packages/integration-tests/tests/validate_from.rs
+++ b/packages/integration-tests/tests/validate_from.rs
@@ -63,7 +63,7 @@ impl SampleKolmeApp {
                 ChainConfig {
                     assets,
                     bridge: BridgeContract::NeededCosmosBridge { code_id },
-                    confirmation_depth: ConfirmationDepth::Disabled,
+                    confirmation_depth: None,
                 },
             )
             .unwrap();

--- a/packages/kolme-test/src/offline_simple.rs
+++ b/packages/kolme-test/src/offline_simple.rs
@@ -62,6 +62,7 @@ impl Default for SampleKolmeApp {
                     bridge: BridgeContract::NeededCosmosBridge {
                         code_id: OSMOSIS_TESTNET_CODE_ID,
                     },
+                    confirmation_depth: None,
                 },
             )
             .unwrap();
@@ -73,6 +74,7 @@ impl Default for SampleKolmeApp {
                     bridge: BridgeContract::NeededCosmosBridge {
                         code_id: NEUTRON_TESTNET_CODE_ID,
                     },
+                    confirmation_depth: None,
                 },
             )
             .unwrap();

--- a/packages/kolme-test/src/offline_simple.rs
+++ b/packages/kolme-test/src/offline_simple.rs
@@ -62,7 +62,7 @@ impl Default for SampleKolmeApp {
                     bridge: BridgeContract::NeededCosmosBridge {
                         code_id: OSMOSIS_TESTNET_CODE_ID,
                     },
-                    confirmation_depth: ConfirmationDepth::Disabled,
+                    confirmation_depth: None,
                 },
             )
             .unwrap();
@@ -74,7 +74,7 @@ impl Default for SampleKolmeApp {
                     bridge: BridgeContract::NeededCosmosBridge {
                         code_id: NEUTRON_TESTNET_CODE_ID,
                     },
-                    confirmation_depth: ConfirmationDepth::Disabled,
+                    confirmation_depth: None,
                 },
             )
             .unwrap();

--- a/packages/kolme-test/src/offline_simple.rs
+++ b/packages/kolme-test/src/offline_simple.rs
@@ -62,7 +62,7 @@ impl Default for SampleKolmeApp {
                     bridge: BridgeContract::NeededCosmosBridge {
                         code_id: OSMOSIS_TESTNET_CODE_ID,
                     },
-                    confirmation_depth: None,
+                    confirmation_depth: ConfirmationDepth::Disabled,
                 },
             )
             .unwrap();
@@ -74,7 +74,7 @@ impl Default for SampleKolmeApp {
                     bridge: BridgeContract::NeededCosmosBridge {
                         code_id: NEUTRON_TESTNET_CODE_ID,
                     },
-                    confirmation_depth: None,
+                    confirmation_depth: ConfirmationDepth::Disabled,
                 },
             )
             .unwrap();

--- a/packages/kolme-test/src/withdraw.rs
+++ b/packages/kolme-test/src/withdraw.rs
@@ -205,6 +205,7 @@ fn genesis_info(validator_set: ValidatorSet, pass_through_port: u16) -> GenesisI
         .insert_pass_through(ChainConfig {
             assets,
             bridge: BridgeContract::Deployed(pass_through_port.to_string()),
+            confirmation_depth: None,
         })
         .unwrap();
 

--- a/packages/kolme-test/src/withdraw.rs
+++ b/packages/kolme-test/src/withdraw.rs
@@ -205,7 +205,7 @@ fn genesis_info(validator_set: ValidatorSet, pass_through_port: u16) -> GenesisI
         .insert_pass_through(ChainConfig {
             assets,
             bridge: BridgeContract::Deployed(pass_through_port.to_string()),
-            confirmation_depth: ConfirmationDepth::Disabled,
+            confirmation_depth: None,
         })
         .unwrap();
 

--- a/packages/kolme-test/src/withdraw.rs
+++ b/packages/kolme-test/src/withdraw.rs
@@ -205,7 +205,7 @@ fn genesis_info(validator_set: ValidatorSet, pass_through_port: u16) -> GenesisI
         .insert_pass_through(ChainConfig {
             assets,
             bridge: BridgeContract::Deployed(pass_through_port.to_string()),
-            confirmation_depth: None,
+            confirmation_depth: ConfirmationDepth::Disabled,
         })
         .unwrap();
 

--- a/packages/kolme/src/core/traits/quickcheck_arbitrary.rs
+++ b/packages/kolme/src/core/traits/quickcheck_arbitrary.rs
@@ -1,6 +1,6 @@
 use crate::core::types::{
     AccountId, AccountNonce, AssetConfig, AssetId, AssetName, BridgeContract, ChainConfig,
-    ExternalChain, Wallet,
+    ConfirmationDepth, ExternalChain, Wallet,
 };
 use quickcheck::{Arbitrary, Gen};
 use std::collections::BTreeMap;
@@ -53,7 +53,14 @@ impl Arbitrary for ChainConfig {
         Self {
             assets: <BTreeMap<AssetName, AssetConfig>>::arbitrary(g),
             bridge: <BridgeContract>::arbitrary(g),
-            confirmation_depth: <Option<u64>>::arbitrary(g),
+            confirmation_depth: g
+                .choose(&[
+                    ConfirmationDepth::UseDefault,
+                    ConfirmationDepth::Disabled,
+                    ConfirmationDepth::Value(<u64>::arbitrary(g)),
+                ])
+                .unwrap()
+                .clone(),
         }
     }
 }

--- a/packages/kolme/src/core/traits/quickcheck_arbitrary.rs
+++ b/packages/kolme/src/core/traits/quickcheck_arbitrary.rs
@@ -1,6 +1,6 @@
 use crate::core::types::{
     AccountId, AccountNonce, AssetConfig, AssetId, AssetName, BridgeContract, ChainConfig,
-    ConfirmationDepth, ExternalChain, Wallet,
+    ExternalChain, Wallet,
 };
 use quickcheck::{Arbitrary, Gen};
 use std::collections::BTreeMap;
@@ -50,18 +50,10 @@ impl Arbitrary for AssetConfig {
 
 impl Arbitrary for ChainConfig {
     fn arbitrary(g: &mut Gen) -> Self {
-        let random_depth = <u64>::arbitrary(g);
         Self {
             assets: <BTreeMap<AssetName, AssetConfig>>::arbitrary(g),
             bridge: <BridgeContract>::arbitrary(g),
-            confirmation_depth: g
-                .choose(&[
-                    ConfirmationDepth::UseDefault,
-                    ConfirmationDepth::Disabled,
-                    ConfirmationDepth::Value(random_depth),
-                ])
-                .unwrap()
-                .clone(),
+            confirmation_depth: <Option<u64>>::arbitrary(g),
         }
     }
 }

--- a/packages/kolme/src/core/traits/quickcheck_arbitrary.rs
+++ b/packages/kolme/src/core/traits/quickcheck_arbitrary.rs
@@ -50,6 +50,7 @@ impl Arbitrary for AssetConfig {
 
 impl Arbitrary for ChainConfig {
     fn arbitrary(g: &mut Gen) -> Self {
+        let random_depth = <u64>::arbitrary(g);
         Self {
             assets: <BTreeMap<AssetName, AssetConfig>>::arbitrary(g),
             bridge: <BridgeContract>::arbitrary(g),
@@ -57,7 +58,7 @@ impl Arbitrary for ChainConfig {
                 .choose(&[
                     ConfirmationDepth::UseDefault,
                     ConfirmationDepth::Disabled,
-                    ConfirmationDepth::Value(<u64>::arbitrary(g)),
+                    ConfirmationDepth::Value(random_depth),
                 ])
                 .unwrap()
                 .clone(),

--- a/packages/kolme/src/core/traits/quickcheck_arbitrary.rs
+++ b/packages/kolme/src/core/traits/quickcheck_arbitrary.rs
@@ -53,6 +53,7 @@ impl Arbitrary for ChainConfig {
         Self {
             assets: <BTreeMap<AssetName, AssetConfig>>::arbitrary(g),
             bridge: <BridgeContract>::arbitrary(g),
+            confirmation_depth: <Option<u64>>::arbitrary(g),
         }
     }
 }

--- a/packages/kolme/src/core/types.rs
+++ b/packages/kolme/src/core/types.rs
@@ -396,6 +396,51 @@ impl MerkleDeserialize for ExternalChain {
 }
 
 #[derive(serde::Serialize, serde::Deserialize, Clone, PartialEq, Eq, Debug)]
+#[serde(rename_all = "snake_case")]
+pub enum ConfirmationDepth {
+    UseDefault,
+    Disabled,
+    Value(u64),
+}
+
+impl ConfirmationDepth {
+    pub const fn use_default() -> Self {
+        Self::UseDefault
+    }
+}
+
+impl MerkleSerialize for ConfirmationDepth {
+    fn merkle_serialize(&self, serializer: &mut MerkleSerializer) -> Result<(), MerkleSerialError> {
+        match self {
+            Self::UseDefault => serializer.store(&0_u8)?,
+            Self::Disabled => serializer.store(&1_u8)?,
+            Self::Value(value) => {
+                serializer.store(&2_u8)?;
+                serializer.store(value)?;
+            }
+        }
+        Ok(())
+    }
+}
+
+impl MerkleDeserialize for ConfirmationDepth {
+    fn merkle_deserialize(
+        deserializer: &mut MerkleDeserializer,
+        _version: usize,
+    ) -> Result<Self, MerkleSerialError> {
+        match deserializer.load::<u8>()? {
+            0 => Ok(Self::UseDefault),
+            1 => Ok(Self::Disabled),
+            2 => Ok(Self::Value(deserializer.load()?)),
+            tag => Err(MerkleSerialError::custom(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!("Unsupported confirmation depth tag: {tag}"),
+            ))),
+        }
+    }
+}
+
+#[derive(serde::Serialize, serde::Deserialize, Clone, PartialEq, Eq, Debug)]
 pub struct ChainConfig {
     pub assets: BTreeMap<AssetName, AssetConfig>,
     pub bridge: BridgeContract,
@@ -403,7 +448,8 @@ pub struct ChainConfig {
     ///
     /// This setting is generic for future chain listeners, but currently enforced
     /// only by the Ethereum listener.
-    pub confirmation_depth: Option<u64>,
+    #[serde(default = "ConfirmationDepth::use_default")]
+    pub confirmation_depth: ConfirmationDepth,
 }
 impl ChainConfig {
     fn into_state(self) -> ChainState {
@@ -613,7 +659,7 @@ impl MerkleDeserialize for ChainConfig {
             assets: deserializer.load()?,
             bridge: deserializer.load()?,
             confirmation_depth: if version == 0 {
-                None
+                ConfirmationDepth::UseDefault
             } else {
                 deserializer.load()?
             },
@@ -2366,14 +2412,15 @@ mod tests {
     fn chain_config_confirmation_depth_defaults_to_none_when_omitted_in_json() {
         let raw = r#"{"assets":{},"bridge":"NeededEthereumBridge"}"#;
         let config: ChainConfig = serde_json::from_str(raw).unwrap();
-        assert_eq!(config.confirmation_depth, None);
+        assert_eq!(config.confirmation_depth, ConfirmationDepth::UseDefault);
     }
 
     #[test]
     fn chain_config_confirmation_depth_honors_explicit_json_override() {
-        let raw = r#"{"assets":{},"bridge":"NeededEthereumBridge","confirmation_depth":42}"#;
+        let raw =
+            r#"{"assets":{},"bridge":"NeededEthereumBridge","confirmation_depth":{"value":42}}"#;
         let config: ChainConfig = serde_json::from_str(raw).unwrap();
-        assert_eq!(config.confirmation_depth, Some(42));
+        assert_eq!(config.confirmation_depth, ConfirmationDepth::Value(42));
     }
 
     #[derive(Clone)]
@@ -2417,7 +2464,7 @@ mod tests {
             .await
             .unwrap();
 
-        assert_eq!(config.confirmation_depth, None);
+        assert_eq!(config.confirmation_depth, ConfirmationDepth::UseDefault);
     }
 
     #[test]
@@ -2486,14 +2533,14 @@ mod tests {
             bridge: BridgeContract::Deployed(
                 "0x0123456789abcdef0123456789abcdef01234567".to_owned(),
             ),
-            confirmation_depth: None,
+            confirmation_depth: ConfirmationDepth::Disabled,
         };
         let mainnet_config = ChainConfig {
             assets: BTreeMap::new(),
             bridge: BridgeContract::Deployed(
                 "0x89abcdef0123456789abcdef0123456789abcdef".to_owned(),
             ),
-            confirmation_depth: None,
+            confirmation_depth: ConfirmationDepth::Disabled,
         };
 
         chains
@@ -2514,17 +2561,17 @@ mod tests {
         let invalid_address = ChainConfig {
             assets: BTreeMap::new(),
             bridge: BridgeContract::Deployed("not-an-address".to_owned()),
-            confirmation_depth: None,
+            confirmation_depth: ConfirmationDepth::Disabled,
         };
         let wrong_contract_kind = ChainConfig {
             assets: BTreeMap::new(),
             bridge: BridgeContract::NeededCosmosBridge { code_id: 1 },
-            confirmation_depth: None,
+            confirmation_depth: ConfirmationDepth::Disabled,
         };
         let ethereum_kind = ChainConfig {
             assets: BTreeMap::new(),
             bridge: BridgeContract::NeededEthereumBridge,
-            confirmation_depth: None,
+            confirmation_depth: ConfirmationDepth::Disabled,
         };
 
         assert!(chains
@@ -2562,7 +2609,7 @@ mod tests {
             bridge: BridgeContract::Deployed(
                 "0xBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB".to_owned(),
             ),
-            confirmation_depth: None,
+            confirmation_depth: ConfirmationDepth::Disabled,
         };
 
         chains
@@ -2589,7 +2636,7 @@ mod tests {
         let config = ChainConfig {
             assets: BTreeMap::new(),
             bridge: BridgeContract::NeededEthereumBridge,
-            confirmation_depth: Some(7),
+            confirmation_depth: ConfirmationDepth::Value(7),
         };
 
         chains
@@ -2597,7 +2644,7 @@ mod tests {
             .unwrap();
 
         let inserted = chains.0.get(&ExternalChain::EthereumLocal).unwrap();
-        assert_eq!(inserted.confirmation_depth, Some(7));
+        assert_eq!(inserted.confirmation_depth, ConfirmationDepth::Value(7));
     }
 
     #[cfg(feature = "ethereum")]
@@ -2633,7 +2680,7 @@ mod tests {
                 },
             )]),
             bridge: BridgeContract::NeededEthereumBridge,
-            confirmation_depth: None,
+            confirmation_depth: ConfirmationDepth::Disabled,
         };
         let action = ExecAction::Transfer {
             chain: ExternalChain::EthereumLocal,
@@ -2670,7 +2717,7 @@ mod tests {
                 },
             )]),
             bridge: BridgeContract::NeededEthereumBridge,
-            confirmation_depth: None,
+            confirmation_depth: ConfirmationDepth::Disabled,
         };
         let action = ExecAction::Transfer {
             chain: ExternalChain::EthereumLocal,

--- a/packages/kolme/src/core/types.rs
+++ b/packages/kolme/src/core/types.rs
@@ -396,51 +396,6 @@ impl MerkleDeserialize for ExternalChain {
 }
 
 #[derive(serde::Serialize, serde::Deserialize, Clone, PartialEq, Eq, Debug)]
-#[serde(rename_all = "snake_case")]
-pub enum ConfirmationDepth {
-    UseDefault,
-    Disabled,
-    Value(u64),
-}
-
-impl ConfirmationDepth {
-    pub const fn use_default() -> Self {
-        Self::UseDefault
-    }
-}
-
-impl MerkleSerialize for ConfirmationDepth {
-    fn merkle_serialize(&self, serializer: &mut MerkleSerializer) -> Result<(), MerkleSerialError> {
-        match self {
-            Self::UseDefault => serializer.store(&0_u8)?,
-            Self::Disabled => serializer.store(&1_u8)?,
-            Self::Value(value) => {
-                serializer.store(&2_u8)?;
-                serializer.store(value)?;
-            }
-        }
-        Ok(())
-    }
-}
-
-impl MerkleDeserialize for ConfirmationDepth {
-    fn merkle_deserialize(
-        deserializer: &mut MerkleDeserializer,
-        _version: usize,
-    ) -> Result<Self, MerkleSerialError> {
-        match deserializer.load::<u8>()? {
-            0 => Ok(Self::UseDefault),
-            1 => Ok(Self::Disabled),
-            2 => Ok(Self::Value(deserializer.load()?)),
-            tag => Err(MerkleSerialError::custom(std::io::Error::new(
-                std::io::ErrorKind::InvalidData,
-                format!("Unsupported confirmation depth tag: {tag}"),
-            ))),
-        }
-    }
-}
-
-#[derive(serde::Serialize, serde::Deserialize, Clone, PartialEq, Eq, Debug)]
 pub struct ChainConfig {
     pub assets: BTreeMap<AssetName, AssetConfig>,
     pub bridge: BridgeContract,
@@ -448,8 +403,7 @@ pub struct ChainConfig {
     ///
     /// This setting is generic for future chain listeners, but currently enforced
     /// only by the Ethereum listener.
-    #[serde(default = "ConfirmationDepth::use_default")]
-    pub confirmation_depth: ConfirmationDepth,
+    pub confirmation_depth: Option<u64>,
 }
 impl ChainConfig {
     fn into_state(self) -> ChainState {
@@ -659,7 +613,7 @@ impl MerkleDeserialize for ChainConfig {
             assets: deserializer.load()?,
             bridge: deserializer.load()?,
             confirmation_depth: if version == 0 {
-                ConfirmationDepth::UseDefault
+                None
             } else {
                 deserializer.load()?
             },
@@ -2412,15 +2366,14 @@ mod tests {
     fn chain_config_confirmation_depth_defaults_to_none_when_omitted_in_json() {
         let raw = r#"{"assets":{},"bridge":"NeededEthereumBridge"}"#;
         let config: ChainConfig = serde_json::from_str(raw).unwrap();
-        assert_eq!(config.confirmation_depth, ConfirmationDepth::UseDefault);
+        assert_eq!(config.confirmation_depth, None);
     }
 
     #[test]
     fn chain_config_confirmation_depth_honors_explicit_json_override() {
-        let raw =
-            r#"{"assets":{},"bridge":"NeededEthereumBridge","confirmation_depth":{"value":42}}"#;
+        let raw = r#"{"assets":{},"bridge":"NeededEthereumBridge","confirmation_depth":42}"#;
         let config: ChainConfig = serde_json::from_str(raw).unwrap();
-        assert_eq!(config.confirmation_depth, ConfirmationDepth::Value(42));
+        assert_eq!(config.confirmation_depth, Some(42));
     }
 
     #[derive(Clone)]
@@ -2464,7 +2417,7 @@ mod tests {
             .await
             .unwrap();
 
-        assert_eq!(config.confirmation_depth, ConfirmationDepth::UseDefault);
+        assert_eq!(config.confirmation_depth, None);
     }
 
     #[test]
@@ -2533,14 +2486,14 @@ mod tests {
             bridge: BridgeContract::Deployed(
                 "0x0123456789abcdef0123456789abcdef01234567".to_owned(),
             ),
-            confirmation_depth: ConfirmationDepth::Disabled,
+            confirmation_depth: None,
         };
         let mainnet_config = ChainConfig {
             assets: BTreeMap::new(),
             bridge: BridgeContract::Deployed(
                 "0x89abcdef0123456789abcdef0123456789abcdef".to_owned(),
             ),
-            confirmation_depth: ConfirmationDepth::Disabled,
+            confirmation_depth: None,
         };
 
         chains
@@ -2561,17 +2514,17 @@ mod tests {
         let invalid_address = ChainConfig {
             assets: BTreeMap::new(),
             bridge: BridgeContract::Deployed("not-an-address".to_owned()),
-            confirmation_depth: ConfirmationDepth::Disabled,
+            confirmation_depth: None,
         };
         let wrong_contract_kind = ChainConfig {
             assets: BTreeMap::new(),
             bridge: BridgeContract::NeededCosmosBridge { code_id: 1 },
-            confirmation_depth: ConfirmationDepth::Disabled,
+            confirmation_depth: None,
         };
         let ethereum_kind = ChainConfig {
             assets: BTreeMap::new(),
             bridge: BridgeContract::NeededEthereumBridge,
-            confirmation_depth: ConfirmationDepth::Disabled,
+            confirmation_depth: None,
         };
 
         assert!(chains
@@ -2609,7 +2562,7 @@ mod tests {
             bridge: BridgeContract::Deployed(
                 "0xBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB".to_owned(),
             ),
-            confirmation_depth: ConfirmationDepth::Disabled,
+            confirmation_depth: None,
         };
 
         chains
@@ -2636,7 +2589,7 @@ mod tests {
         let config = ChainConfig {
             assets: BTreeMap::new(),
             bridge: BridgeContract::NeededEthereumBridge,
-            confirmation_depth: ConfirmationDepth::Value(7),
+            confirmation_depth: Some(7),
         };
 
         chains
@@ -2644,7 +2597,7 @@ mod tests {
             .unwrap();
 
         let inserted = chains.0.get(&ExternalChain::EthereumLocal).unwrap();
-        assert_eq!(inserted.confirmation_depth, ConfirmationDepth::Value(7));
+        assert_eq!(inserted.confirmation_depth, Some(7));
     }
 
     #[cfg(feature = "ethereum")]
@@ -2680,7 +2633,7 @@ mod tests {
                 },
             )]),
             bridge: BridgeContract::NeededEthereumBridge,
-            confirmation_depth: ConfirmationDepth::Disabled,
+            confirmation_depth: None,
         };
         let action = ExecAction::Transfer {
             chain: ExternalChain::EthereumLocal,
@@ -2717,7 +2670,7 @@ mod tests {
                 },
             )]),
             bridge: BridgeContract::NeededEthereumBridge,
-            confirmation_depth: ConfirmationDepth::Disabled,
+            confirmation_depth: None,
         };
         let action = ExecAction::Transfer {
             chain: ExternalChain::EthereumLocal,

--- a/packages/kolme/src/core/types.rs
+++ b/packages/kolme/src/core/types.rs
@@ -399,6 +399,11 @@ impl MerkleDeserialize for ExternalChain {
 pub struct ChainConfig {
     pub assets: BTreeMap<AssetName, AssetConfig>,
     pub bridge: BridgeContract,
+    /// Confirmation depth for bridge event ingestion.
+    ///
+    /// This setting is generic for future chain listeners, but currently enforced
+    /// only by the Ethereum listener.
+    pub confirmation_depth: Option<u64>,
 }
 impl ChainConfig {
     fn into_state(self) -> ChainState {
@@ -582,10 +587,19 @@ impl MerkleDeserialize for PendingBridgeEvent {
 }
 
 impl MerkleSerialize for ChainConfig {
+    fn merkle_version() -> usize {
+        1
+    }
+
     fn merkle_serialize(&self, serializer: &mut MerkleSerializer) -> Result<(), MerkleSerialError> {
-        let ChainConfig { assets, bridge } = self;
+        let ChainConfig {
+            assets,
+            bridge,
+            confirmation_depth,
+        } = self;
         serializer.store(assets)?;
         serializer.store(bridge)?;
+        serializer.store(confirmation_depth)?;
         Ok(())
     }
 }
@@ -593,11 +607,16 @@ impl MerkleSerialize for ChainConfig {
 impl MerkleDeserialize for ChainConfig {
     fn merkle_deserialize(
         deserializer: &mut MerkleDeserializer,
-        _version: usize,
+        version: usize,
     ) -> Result<Self, MerkleSerialError> {
         Ok(Self {
             assets: deserializer.load()?,
             bridge: deserializer.load()?,
+            confirmation_depth: if version == 0 {
+                None
+            } else {
+                deserializer.load()?
+            },
         })
     }
 }
@@ -2219,6 +2238,7 @@ mod tests {
     use super::*;
     #[cfg(feature = "ethereum")]
     use alloy::primitives::Address;
+    use merkle_map::{MerkleDeserialize, MerkleSerialize, MerkleSerializer};
     use quickcheck::quickcheck;
     use rust_decimal::dec;
     use std::collections::BTreeMap;
@@ -2343,6 +2363,64 @@ mod tests {
     }
 
     #[test]
+    fn chain_config_confirmation_depth_defaults_to_none_when_omitted_in_json() {
+        let raw = r#"{"assets":{},"bridge":"NeededEthereumBridge"}"#;
+        let config: ChainConfig = serde_json::from_str(raw).unwrap();
+        assert_eq!(config.confirmation_depth, None);
+    }
+
+    #[test]
+    fn chain_config_confirmation_depth_honors_explicit_json_override() {
+        let raw = r#"{"assets":{},"bridge":"NeededEthereumBridge","confirmation_depth":42}"#;
+        let config: ChainConfig = serde_json::from_str(raw).unwrap();
+        assert_eq!(config.confirmation_depth, Some(42));
+    }
+
+    #[derive(Clone)]
+    struct LegacyChainConfig {
+        assets: BTreeMap<AssetName, AssetConfig>,
+        bridge: BridgeContract,
+    }
+
+    impl MerkleSerialize for LegacyChainConfig {
+        fn merkle_serialize(
+            &self,
+            serializer: &mut MerkleSerializer,
+        ) -> Result<(), MerkleSerialError> {
+            serializer.store(&self.assets)?;
+            serializer.store(&self.bridge)?;
+            Ok(())
+        }
+    }
+
+    impl MerkleDeserialize for LegacyChainConfig {
+        fn merkle_deserialize(
+            deserializer: &mut merkle_map::MerkleDeserializer,
+            _version: usize,
+        ) -> Result<Self, MerkleSerialError> {
+            Ok(Self {
+                assets: deserializer.load()?,
+                bridge: deserializer.load()?,
+            })
+        }
+    }
+
+    #[tokio::test]
+    async fn chain_config_merkle_v0_defaults_confirmation_depth_to_none() {
+        let mut store = MerkleMemoryStore::default();
+        let legacy = LegacyChainConfig {
+            assets: BTreeMap::new(),
+            bridge: BridgeContract::NeededEthereumBridge,
+        };
+        let hash = merkle_map::save(&mut store, &legacy).await.unwrap();
+        let config = merkle_map::load::<ChainConfig, _>(&mut store, hash)
+            .await
+            .unwrap();
+
+        assert_eq!(config.confirmation_depth, None);
+    }
+
+    #[test]
     fn ethereum_chain_conversions() {
         assert_eq!(
             ExternalChain::from(EthereumChain::Mainnet),
@@ -2408,12 +2486,14 @@ mod tests {
             bridge: BridgeContract::Deployed(
                 "0x0123456789abcdef0123456789abcdef01234567".to_owned(),
             ),
+            confirmation_depth: None,
         };
         let mainnet_config = ChainConfig {
             assets: BTreeMap::new(),
             bridge: BridgeContract::Deployed(
                 "0x89abcdef0123456789abcdef0123456789abcdef".to_owned(),
             ),
+            confirmation_depth: None,
         };
 
         chains
@@ -2434,14 +2514,17 @@ mod tests {
         let invalid_address = ChainConfig {
             assets: BTreeMap::new(),
             bridge: BridgeContract::Deployed("not-an-address".to_owned()),
+            confirmation_depth: None,
         };
         let wrong_contract_kind = ChainConfig {
             assets: BTreeMap::new(),
             bridge: BridgeContract::NeededCosmosBridge { code_id: 1 },
+            confirmation_depth: None,
         };
         let ethereum_kind = ChainConfig {
             assets: BTreeMap::new(),
             bridge: BridgeContract::NeededEthereumBridge,
+            confirmation_depth: None,
         };
 
         assert!(chains
@@ -2479,6 +2562,7 @@ mod tests {
             bridge: BridgeContract::Deployed(
                 "0xBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB".to_owned(),
             ),
+            confirmation_depth: None,
         };
 
         chains
@@ -2496,6 +2580,24 @@ mod tests {
         assert!(inserted.assets.contains_key(&AssetName(
             "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".to_owned()
         )));
+    }
+
+    #[cfg(feature = "ethereum")]
+    #[test]
+    fn insert_ethereum_preserves_explicit_confirmation_depth_override() {
+        let mut chains = ConfiguredChains::default();
+        let config = ChainConfig {
+            assets: BTreeMap::new(),
+            bridge: BridgeContract::NeededEthereumBridge,
+            confirmation_depth: Some(7),
+        };
+
+        chains
+            .insert_ethereum(EthereumChain::Local, config)
+            .unwrap();
+
+        let inserted = chains.0.get(&ExternalChain::EthereumLocal).unwrap();
+        assert_eq!(inserted.confirmation_depth, Some(7));
     }
 
     #[cfg(feature = "ethereum")]
@@ -2531,6 +2633,7 @@ mod tests {
                 },
             )]),
             bridge: BridgeContract::NeededEthereumBridge,
+            confirmation_depth: None,
         };
         let action = ExecAction::Transfer {
             chain: ExternalChain::EthereumLocal,
@@ -2567,6 +2670,7 @@ mod tests {
                 },
             )]),
             bridge: BridgeContract::NeededEthereumBridge,
+            confirmation_depth: None,
         };
         let action = ExecAction::Transfer {
             chain: ExternalChain::EthereumLocal,

--- a/packages/kolme/src/listener/ethereum.rs
+++ b/packages/kolme/src/listener/ethereum.rs
@@ -13,27 +13,12 @@ use futures_util::StreamExt;
 
 use super::get_next_bridge_event_id;
 
-const POLL_INTERVAL: tokio::time::Duration = tokio::time::Duration::from_secs(1);
+// Ethereum block times are typically >= 4s on public networks (e.g. ~12s on mainnet),
+// so polling every 4s significantly reduces RPC load with negligible freshness impact.
+// Keep local polling at 1s for fast dev/test feedback loops.
+const POLL_INTERVAL_LOCAL: tokio::time::Duration = tokio::time::Duration::from_secs(1);
+const POLL_INTERVAL_DEFAULT: tokio::time::Duration = tokio::time::Duration::from_secs(4);
 const WS_RETRY_INTERVAL: tokio::time::Duration = tokio::time::Duration::from_secs(30);
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-enum EthereumListenerMode {
-    Hybrid,
-    SubscriptionOnly,
-}
-
-impl EthereumListenerMode {
-    fn from_env_value(value: Option<&str>) -> Self {
-        match value.map(str::trim).map(str::to_ascii_lowercase).as_deref() {
-            Some("subscription-only") => Self::SubscriptionOnly,
-            _ => Self::Hybrid,
-        }
-    }
-
-    fn from_env() -> Self {
-        Self::from_env_value(std::env::var("KOLME_ETH_LISTENER_MODE").ok().as_deref())
-    }
-}
 
 sol! {
     event FundsReceived(uint64 indexed eventId, address indexed sender, address[] tokens, uint256[] amounts, bytes[] keys);
@@ -147,7 +132,6 @@ pub async fn listen<App: KolmeApp>(
     contract: String,
 ) -> Result<()> {
     let chain: ExternalChain = ethereum_chain.into();
-    let mode = EthereumListenerMode::from_env();
     let contract: Address = contract
         .parse()
         .with_context(|| format!("Invalid Ethereum contract address: {contract}"))?;
@@ -167,19 +151,11 @@ pub async fn listen<App: KolmeApp>(
         "Beginning Ethereum listener loop on chain {chain:?}, contract {:#x}, next event ID: {next_bridge_event_id}, next block: {next_block}, first log index: {first_log_index:?}",
         contract.address()
     );
-    tracing::info!(
-        "Ethereum listener mode on chain {chain:?}: {:?} (env KOLME_ETH_LISTENER_MODE={})",
-        mode,
-        std::env::var("KOLME_ETH_LISTENER_MODE")
-            .as_deref()
-            .unwrap_or("<unset>")
-    );
 
     listen_with_ws_retry(
         &kolme,
         &secret,
         ethereum_chain,
-        mode,
         &contract,
         &mut next_bridge_event_id,
         &mut next_block,
@@ -204,44 +180,55 @@ async fn connect_ws(
     ))
 }
 
-#[allow(clippy::too_many_arguments)]
 async fn listen_with_ws_retry<App: KolmeApp, P: Provider>(
     kolme: &Kolme<App>,
     secret: &SecretKey,
     ethereum_chain: EthereumChain,
-    mode: EthereumListenerMode,
     contract: &ContractInstance<P>,
     next_bridge_event_id: &mut BridgeEventId,
     next_block: &mut u64,
     first_log_index: &mut Option<u64>,
 ) -> Result<()> {
     let chain: ExternalChain = ethereum_chain.into();
+    let contract_address = *contract.address();
+    let poll_interval = match ethereum_chain {
+        EthereumChain::Local => POLL_INTERVAL_LOCAL,
+        EthereumChain::Mainnet | EthereumChain::Sepolia => POLL_INTERVAL_DEFAULT,
+    };
     let mut next_ws_retry = tokio::time::Instant::now();
+    let mut subscriber_task: Option<tokio::task::JoinHandle<()>> = None;
 
     loop {
-        if tokio::time::Instant::now() >= next_ws_retry {
-            let ws_result = try_ws_session_once(
-                kolme,
-                secret,
-                ethereum_chain,
-                *contract.address(),
-                next_bridge_event_id,
-                next_block,
-                first_log_index,
-            )
-            .await;
-            if let Err(e) = ws_result {
-                if matches!(mode, EthereumListenerMode::SubscriptionOnly) {
-                    return Err(e);
+        // Every WS_RETRY_INTERVAL seconds, check whether subscriber task is running.
+        // If there is none, spawn one.
+        if subscriber_task
+            .as_ref()
+            .is_some_and(tokio::task::JoinHandle::is_finished)
+        {
+            if let Some(handle) = subscriber_task.take() {
+                if let Err(e) = handle.await {
+                    tracing::warn!(
+                        "Ethereum listener subscriber task join failed on chain {chain:?}: {e}"
+                    );
                 }
             }
-
-            next_ws_retry = tokio::time::Instant::now() + WS_RETRY_INTERVAL;
         }
 
-        if matches!(mode, EthereumListenerMode::SubscriptionOnly) {
-            tokio::time::sleep(POLL_INTERVAL).await;
-            continue;
+        if tokio::time::Instant::now() >= next_ws_retry {
+            next_ws_retry = tokio::time::Instant::now() + WS_RETRY_INTERVAL;
+            if subscriber_task.is_none() {
+                let kolme = kolme.clone();
+                let secret = secret.clone();
+                subscriber_task = Some(tokio::spawn(async move {
+                    if let Err(e) =
+                        try_ws_session_once(&kolme, &secret, ethereum_chain, contract_address).await
+                    {
+                        tracing::debug!(
+                            "Ethereum listener subscriber session ended on chain {chain:?}: {e}"
+                        );
+                    }
+                }));
+            }
         }
 
         listen_polling_once(
@@ -254,7 +241,7 @@ async fn listen_with_ws_retry<App: KolmeApp, P: Provider>(
             first_log_index,
         )
         .await?;
-        tokio::time::sleep(POLL_INTERVAL).await;
+        tokio::time::sleep(poll_interval).await;
     }
 }
 
@@ -263,9 +250,6 @@ async fn try_ws_session_once<App: KolmeApp>(
     secret: &SecretKey,
     ethereum_chain: EthereumChain,
     contract_address: Address,
-    next_bridge_event_id: &mut BridgeEventId,
-    next_block: &mut u64,
-    first_log_index: &mut Option<u64>,
 ) -> Result<()> {
     let chain: ExternalChain = ethereum_chain.into();
     let ws_contract = match connect_ws(ethereum_chain, contract_address).await {
@@ -286,17 +270,7 @@ async fn try_ws_session_once<App: KolmeApp>(
         }
     };
 
-    if let Err(e) = listen_with_subscription(
-        kolme,
-        secret,
-        chain,
-        &ws_contract,
-        next_bridge_event_id,
-        next_block,
-        first_log_index,
-    )
-    .await
-    {
+    if let Err(e) = listen_with_subscription(kolme, secret, chain, &ws_contract).await {
         tracing::warn!(
             "Ethereum listener subscription failed on chain {chain:?}, contract {:#x}: {e}; continuing with polling and retrying WS in {}s",
             ws_contract.address(),
@@ -366,33 +340,30 @@ pub async fn sanity_check_contract(
 }
 
 async fn listen_with_subscription<App: KolmeApp, P: Provider>(
-    kolme: &Kolme<App>,
-    secret: &SecretKey,
+    _kolme: &Kolme<App>,
+    _secret: &SecretKey,
     chain: ExternalChain,
     contract: &ContractInstance<P>,
-    next_bridge_event_id: &mut BridgeEventId,
-    next_block: &mut u64,
-    first_log_index: &mut Option<u64>,
 ) -> Result<()> {
     let filter = Filter::new()
-        .from_block(*next_block)
+        .from_block(BlockNumberOrTag::Latest)
         .address(*contract.address())
         .event_signature(FundsReceived::SIGNATURE_HASH);
     let sub = contract.provider().subscribe_logs(&filter).await?;
     let mut stream = sub.into_stream();
 
     while let Some(log) = stream.next().await {
-        if should_skip_log(&log, *next_block, *first_log_index) {
-            tracing::debug!("Skipping Ethereum subscription log: {:?}", log);
+        if log.removed {
             continue;
         }
-
-        process_event(kolme, secret, chain, &log, next_bridge_event_id).await?;
-
-        if let Some(block_number) = log.block_number {
-            *next_block = block_number;
+        if let Some(event) = EthereumBridgeEvent::from_log(&log)? {
+            tracing::debug!(
+                "Ethereum subscription observed event {} on chain {chain:?} at block {:?}, log index {:?}",
+                event.event_id(),
+                log.block_number,
+                log.log_index
+            );
         }
-        *first_log_index = log.log_index.map(|i| i.saturating_add(1));
     }
 
     Ok(())
@@ -407,14 +378,30 @@ async fn listen_polling_once<App: KolmeApp, P: Provider>(
     next_block: &mut u64,
     first_log_index: &mut Option<u64>,
 ) -> Result<()> {
+    let confirmation_depth = kolme
+        .read()
+        .get_framework_state()
+        .get_chain_states()
+        .get(chain)
+        .ok()
+        .and_then(|state| state.config.confirmation_depth);
+
     let latest = contract.provider().get_block_number().await?;
-    if *next_block > latest {
+
+    let Some(confirmed_head) =
+        confirmation_depth.map_or(Some(latest), |depth| latest.checked_sub(depth))
+    else {
+        // edge case: total chain length is less than confirmation_depth
+        return Ok(());
+    };
+
+    if *next_block > confirmed_head {
         return Ok(());
     }
 
     let filter = Filter::new()
         .from_block(*next_block)
-        .to_block(latest)
+        .to_block(confirmed_head)
         .address(*contract.address());
 
     for log in contract.provider().get_logs(&filter).await? {
@@ -425,7 +412,7 @@ async fn listen_polling_once<App: KolmeApp, P: Provider>(
         process_event(kolme, secret, chain, &log, next_bridge_event_id).await?;
     }
 
-    *next_block = latest.saturating_add(1);
+    *next_block = confirmed_head.saturating_add(1);
     *first_log_index = None;
     Ok(())
 }
@@ -695,37 +682,5 @@ mod tests {
     #[test]
     fn u256_to_u128_rejects_overflow() {
         assert!(u256_to_u128(U256::from(u128::MAX) + U256::from(1)).is_err());
-    }
-
-    #[test]
-    fn ethereum_listener_mode_parser_defaults_to_hybrid() {
-        assert_eq!(
-            EthereumListenerMode::from_env_value(None),
-            EthereumListenerMode::Hybrid
-        );
-        assert_eq!(
-            EthereumListenerMode::from_env_value(Some("")),
-            EthereumListenerMode::Hybrid
-        );
-        assert_eq!(
-            EthereumListenerMode::from_env_value(Some("hybrid")),
-            EthereumListenerMode::Hybrid
-        );
-    }
-
-    #[test]
-    fn ethereum_listener_mode_parser_accepts_subscription_only() {
-        assert_eq!(
-            EthereumListenerMode::from_env_value(Some("subscription-only")),
-            EthereumListenerMode::SubscriptionOnly
-        );
-        assert_eq!(
-            EthereumListenerMode::from_env_value(Some("  subscription-only ")),
-            EthereumListenerMode::SubscriptionOnly
-        );
-        assert_eq!(
-            EthereumListenerMode::from_env_value(Some("SUBSCRIPTION-ONLY")),
-            EthereumListenerMode::SubscriptionOnly
-        );
     }
 }

--- a/packages/kolme/src/listener/ethereum.rs
+++ b/packages/kolme/src/listener/ethereum.rs
@@ -10,6 +10,7 @@ use alloy::{
     sol_types::SolEvent,
 };
 use futures_util::StreamExt;
+use std::collections::VecDeque;
 
 use super::get_next_bridge_event_id;
 
@@ -19,6 +20,15 @@ use super::get_next_bridge_event_id;
 const POLL_INTERVAL_LOCAL: tokio::time::Duration = tokio::time::Duration::from_secs(1);
 const POLL_INTERVAL_DEFAULT: tokio::time::Duration = tokio::time::Duration::from_secs(4);
 const WS_RETRY_INTERVAL: tokio::time::Duration = tokio::time::Duration::from_secs(30);
+const SUBSCRIBER_HINT_CAPACITY: usize = 256;
+
+#[derive(Clone, Copy, Debug)]
+struct SubscriberHint {
+    event_id: BridgeEventId,
+    block_number: u64,
+}
+
+type SubscriberHintState = Arc<tokio::sync::RwLock<VecDeque<SubscriberHint>>>;
 
 sol! {
     event FundsReceived(uint64 indexed eventId, address indexed sender, address[] tokens, uint256[] amounts, bytes[] keys);
@@ -146,6 +156,7 @@ pub async fn listen<App: KolmeApp>(
 
     let (mut next_block, mut first_log_index) =
         get_resume_cursor(&contract, next_bridge_event_id).await?;
+    let subscriber_hint: SubscriberHintState = Arc::new(tokio::sync::RwLock::new(VecDeque::new()));
 
     tracing::info!(
         "Beginning Ethereum listener loop on chain {chain:?}, contract {:#x}, next event ID: {next_bridge_event_id}, next block: {next_block}, first log index: {first_log_index:?}",
@@ -157,6 +168,7 @@ pub async fn listen<App: KolmeApp>(
         &secret,
         ethereum_chain,
         &contract,
+        &subscriber_hint,
         &mut next_bridge_event_id,
         &mut next_block,
         &mut first_log_index,
@@ -180,11 +192,13 @@ async fn connect_ws(
     ))
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn listen_with_ws_retry<App: KolmeApp, P: Provider>(
     kolme: &Kolme<App>,
     secret: &SecretKey,
     ethereum_chain: EthereumChain,
     contract: &ContractInstance<P>,
+    subscriber_hint: &SubscriberHintState,
     next_bridge_event_id: &mut BridgeEventId,
     next_block: &mut u64,
     first_log_index: &mut Option<u64>,
@@ -219,9 +233,16 @@ async fn listen_with_ws_retry<App: KolmeApp, P: Provider>(
             if subscriber_task.is_none() {
                 let kolme = kolme.clone();
                 let secret = secret.clone();
+                let subscriber_hint = subscriber_hint.clone();
                 subscriber_task = Some(tokio::spawn(async move {
-                    if let Err(e) =
-                        try_ws_session_once(&kolme, &secret, ethereum_chain, contract_address).await
+                    if let Err(e) = try_ws_session_once(
+                        &kolme,
+                        &secret,
+                        ethereum_chain,
+                        contract_address,
+                        &subscriber_hint,
+                    )
+                    .await
                     {
                         tracing::debug!(
                             "Ethereum listener subscriber session ended on chain {chain:?}: {e}"
@@ -236,6 +257,7 @@ async fn listen_with_ws_retry<App: KolmeApp, P: Provider>(
             secret,
             chain,
             contract,
+            subscriber_hint,
             next_bridge_event_id,
             next_block,
             first_log_index,
@@ -250,6 +272,7 @@ async fn try_ws_session_once<App: KolmeApp>(
     secret: &SecretKey,
     ethereum_chain: EthereumChain,
     contract_address: Address,
+    subscriber_hint: &SubscriberHintState,
 ) -> Result<()> {
     let chain: ExternalChain = ethereum_chain.into();
     let ws_contract = match connect_ws(ethereum_chain, contract_address).await {
@@ -270,7 +293,9 @@ async fn try_ws_session_once<App: KolmeApp>(
         }
     };
 
-    if let Err(e) = listen_with_subscription(kolme, secret, chain, &ws_contract).await {
+    if let Err(e) =
+        listen_with_subscription(kolme, secret, chain, &ws_contract, subscriber_hint).await
+    {
         tracing::warn!(
             "Ethereum listener subscription failed on chain {chain:?}, contract {:#x}: {e}; continuing with polling and retrying WS in {}s",
             ws_contract.address(),
@@ -344,6 +369,7 @@ async fn listen_with_subscription<App: KolmeApp, P: Provider>(
     _secret: &SecretKey,
     chain: ExternalChain,
     contract: &ContractInstance<P>,
+    subscriber_hint: &SubscriberHintState,
 ) -> Result<()> {
     let filter = Filter::new()
         .from_block(BlockNumberOrTag::Latest)
@@ -357,6 +383,23 @@ async fn listen_with_subscription<App: KolmeApp, P: Provider>(
             continue;
         }
         if let Some(event) = EthereumBridgeEvent::from_log(&log)? {
+            if let Some(block_number) = log.block_number {
+                let mut hints = subscriber_hint.write().await;
+                hints.push_back(SubscriberHint {
+                    event_id: event.event_id(),
+                    block_number,
+                });
+                while hints.len() > SUBSCRIBER_HINT_CAPACITY {
+                    if let Some(evicted) = hints.pop_front() {
+                        tracing::debug!(
+                            "Ethereum subscriber hint queue full (capacity {}), evicting oldest hint: event_id={}, block_number={}",
+                            SUBSCRIBER_HINT_CAPACITY,
+                            evicted.event_id,
+                            evicted.block_number
+                        );
+                    }
+                }
+            }
             tracing::debug!(
                 "Ethereum subscription observed event {} on chain {chain:?} at block {:?}, log index {:?}",
                 event.event_id(),
@@ -369,11 +412,13 @@ async fn listen_with_subscription<App: KolmeApp, P: Provider>(
     Ok(())
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn listen_polling_once<App: KolmeApp, P: Provider>(
     kolme: &Kolme<App>,
     secret: &SecretKey,
     chain: ExternalChain,
     contract: &ContractInstance<P>,
+    subscriber_hint: &SubscriberHintState,
     next_bridge_event_id: &mut BridgeEventId,
     next_block: &mut u64,
     first_log_index: &mut Option<u64>,
@@ -399,22 +444,100 @@ async fn listen_polling_once<App: KolmeApp, P: Provider>(
         return Ok(());
     }
 
-    let filter = Filter::new()
-        .from_block(*next_block)
-        .to_block(confirmed_head)
-        .address(*contract.address());
-
-    for log in contract.provider().get_logs(&filter).await? {
-        if should_skip_log(&log, *next_block, *first_log_index) {
-            continue;
+    // Look if any hints were left by subscriber
+    let hinted_upper_bound = {
+        let mut hints = subscriber_hint.write().await;
+        while hints
+            .front()
+            .is_some_and(|hint| hint.event_id < *next_bridge_event_id)
+        {
+            hints.pop_front();
         }
+        match hints.front().copied() {
+            Some(hint)
+                if hint.event_id == *next_bridge_event_id
+                    && hint.block_number <= confirmed_head =>
+            {
+                hints.pop_front().map(|hint| hint.block_number)
+            }
+            _ => None,
+        }
+    };
+    let usable_hint = hinted_upper_bound.filter(|hint| *hint >= *next_block);
+    let expected_event_id = *next_bridge_event_id;
 
-        process_event(kolme, secret, chain, &log, next_bridge_event_id).await?;
+    if let Some(hint_block) = usable_hint {
+        // Try a direct probe on the hinted block first.
+        let fast_track_first_log_index = if hint_block == *next_block {
+            *first_log_index
+        } else {
+            None
+        };
+        let hinted_event_id = process_range(
+            contract,
+            kolme,
+            secret,
+            chain,
+            hint_block,
+            fast_track_first_log_index,
+            expected_event_id,
+            hint_block,
+        )
+        .await?;
+
+        if hinted_event_id != expected_event_id {
+            // Hint helped, the event was processed - lets do an early exit to get
+            // back in a next iteration
+            *next_bridge_event_id = hinted_event_id;
+            *next_block = hint_block.saturating_add(1);
+            *first_log_index = None;
+            return Ok(());
+        }
     }
 
+    // Hint missing or probe did not help; poll normally up to confirmed head.
+    *next_bridge_event_id = process_range(
+        contract,
+        kolme,
+        secret,
+        chain,
+        *next_block,
+        *first_log_index,
+        expected_event_id,
+        confirmed_head,
+    )
+    .await?;
     *next_block = confirmed_head.saturating_add(1);
     *first_log_index = None;
     Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn process_range<App: KolmeApp, P: Provider>(
+    contract: &ContractInstance<P>,
+    kolme: &Kolme<App>,
+    secret: &SecretKey,
+    chain: ExternalChain,
+    next_block: u64,
+    first_log_index: Option<u64>,
+    next_bridge_event_id: BridgeEventId,
+    to_block: u64,
+) -> Result<BridgeEventId> {
+    let filter = Filter::new()
+        .from_block(next_block)
+        .to_block(to_block)
+        .address(*contract.address());
+
+    let mut next_bridge_event_id = next_bridge_event_id;
+    for log in contract.provider().get_logs(&filter).await? {
+        if should_skip_log(&log, next_block, first_log_index) {
+            continue;
+        }
+
+        process_event(kolme, secret, chain, &log, &mut next_bridge_event_id).await?;
+    }
+
+    Ok(next_bridge_event_id)
 }
 
 fn should_skip_log(log: &Log, next_block: u64, first_log_index: Option<u64>) -> bool {

--- a/packages/kolme/src/listener/ethereum.rs
+++ b/packages/kolme/src/listener/ethereum.rs
@@ -1,4 +1,4 @@
-use crate::utils::ethereum::{token_address_to_denom, DEFAULT_ETHEREUM_CONFIRMATION_DEPTH};
+use crate::utils::ethereum::token_address_to_denom;
 use crate::*;
 use alloy::{
     contract::{ContractInstance, Interface},
@@ -445,12 +445,7 @@ async fn listen_polling_once<App: KolmeApp, P: Provider>(
         .get_chain_states()
         .get(chain)
         .ok()
-        .map(|state| match state.config.confirmation_depth {
-            ConfirmationDepth::UseDefault => Some(DEFAULT_ETHEREUM_CONFIRMATION_DEPTH),
-            ConfirmationDepth::Disabled => None,
-            ConfirmationDepth::Value(depth) => Some(depth),
-        })
-        .unwrap_or(Some(DEFAULT_ETHEREUM_CONFIRMATION_DEPTH));
+        .and_then(|state| state.config.confirmation_depth);
 
     let latest = contract.provider().get_block_number().await?;
 

--- a/packages/kolme/src/listener/ethereum.rs
+++ b/packages/kolme/src/listener/ethereum.rs
@@ -452,21 +452,7 @@ async fn listen_polling_once<App: KolmeApp, P: Provider>(
     // Look if any hints were left by subscriber
     let hinted_upper_bound = {
         let mut hints = subscriber_hint.write().await;
-        while hints
-            .front()
-            .is_some_and(|hint| hint.event_id < *next_bridge_event_id)
-        {
-            hints.pop_front();
-        }
-        match hints.front().copied() {
-            Some(hint)
-                if hint.event_id == *next_bridge_event_id
-                    && hint.block_number <= confirmed_head =>
-            {
-                hints.pop_front().map(|hint| hint.block_number)
-            }
-            _ => None,
-        }
+        take_next_usable_hint_upper_bound(&mut hints, *next_bridge_event_id, confirmed_head)
     };
     let usable_hint = hinted_upper_bound.filter(|hint| *hint >= *next_block);
     let expected_event_id = *next_bridge_event_id;
@@ -515,6 +501,28 @@ async fn listen_polling_once<App: KolmeApp, P: Provider>(
     *next_block = confirmed_head.saturating_add(1);
     *first_log_index = None;
     Ok(())
+}
+
+fn take_next_usable_hint_upper_bound(
+    hints: &mut VecDeque<SubscriberHint>,
+    next_bridge_event_id: BridgeEventId,
+    confirmed_head: u64,
+) -> Option<u64> {
+    while hints
+        .front()
+        .is_some_and(|hint| hint.event_id < next_bridge_event_id)
+    {
+        hints.pop_front();
+    }
+
+    match hints.front().copied() {
+        Some(hint)
+            if hint.event_id == next_bridge_event_id && hint.block_number <= confirmed_head =>
+        {
+            hints.pop_front().map(|hint| hint.block_number)
+        }
+        _ => None,
+    }
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -664,6 +672,7 @@ fn u256_to_u128(value: U256) -> Result<u128> {
 mod tests {
     use super::*;
     use alloy::{primitives::B256, rpc::types::eth::Log};
+    use std::collections::VecDeque;
 
     #[test]
     fn funds_received_topic_hash_matches_constant() {
@@ -810,5 +819,55 @@ mod tests {
     #[test]
     fn u256_to_u128_rejects_overflow() {
         assert!(u256_to_u128(U256::from(u128::MAX) + U256::from(1)).is_err());
+    }
+
+    #[test]
+    fn hint_queue_drops_stale_then_uses_matching_confirmed_hint() {
+        let mut hints = VecDeque::from([
+            SubscriberHint {
+                event_id: BridgeEventId(1),
+                block_number: 10,
+            },
+            SubscriberHint {
+                event_id: BridgeEventId(2),
+                block_number: 12,
+            },
+        ]);
+
+        let upper_bound = take_next_usable_hint_upper_bound(&mut hints, BridgeEventId(2), 20);
+
+        assert_eq!(upper_bound, Some(12));
+        assert!(hints.is_empty());
+    }
+
+    #[test]
+    fn hint_queue_keeps_front_when_event_id_is_ahead_of_next() {
+        let mut hints = VecDeque::from([SubscriberHint {
+            event_id: BridgeEventId(3),
+            block_number: 8,
+        }]);
+
+        let upper_bound = take_next_usable_hint_upper_bound(&mut hints, BridgeEventId(2), 20);
+
+        assert_eq!(upper_bound, None);
+        assert_eq!(hints.len(), 1);
+        assert_eq!(
+            hints.front().map(|hint| hint.event_id),
+            Some(BridgeEventId(3))
+        );
+    }
+
+    #[test]
+    fn hint_queue_keeps_front_when_block_is_above_confirmed_head() {
+        let mut hints = VecDeque::from([SubscriberHint {
+            event_id: BridgeEventId(2),
+            block_number: 50,
+        }]);
+
+        let upper_bound = take_next_usable_hint_upper_bound(&mut hints, BridgeEventId(2), 20);
+
+        assert_eq!(upper_bound, None);
+        assert_eq!(hints.len(), 1);
+        assert_eq!(hints.front().map(|hint| hint.block_number), Some(50));
     }
 }

--- a/packages/kolme/src/listener/ethereum.rs
+++ b/packages/kolme/src/listener/ethereum.rs
@@ -20,6 +20,7 @@ use super::get_next_bridge_event_id;
 const POLL_INTERVAL_LOCAL: tokio::time::Duration = tokio::time::Duration::from_secs(1);
 const POLL_INTERVAL_DEFAULT: tokio::time::Duration = tokio::time::Duration::from_secs(4);
 const WS_RETRY_INTERVAL: tokio::time::Duration = tokio::time::Duration::from_secs(30);
+const SUBSCRIBER_MAX_RETRIES: u32 = 3;
 const SUBSCRIBER_HINT_CAPACITY: usize = 256;
 
 #[derive(Clone, Copy, Debug)]
@@ -29,6 +30,37 @@ struct SubscriberHint {
 }
 
 type SubscriberHintState = Arc<tokio::sync::RwLock<VecDeque<SubscriberHint>>>;
+
+#[derive(Default)]
+struct SubscriberTaskGuard {
+    handle: Option<tokio::task::JoinHandle<()>>,
+}
+
+impl SubscriberTaskGuard {
+    fn set(&mut self, handle: tokio::task::JoinHandle<()>) {
+        self.handle = Some(handle);
+    }
+
+    fn take(&mut self) -> Option<tokio::task::JoinHandle<()>> {
+        self.handle.take()
+    }
+}
+
+impl Drop for SubscriberTaskGuard {
+    fn drop(&mut self) {
+        if let Some(handle) = self.handle.take() {
+            handle.abort();
+        }
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+enum SubscriberSessionError {
+    #[error("subscriber startup failed: {0}")]
+    Startup(#[source] anyhow::Error),
+    #[error("subscriber runtime failed: {0}")]
+    Runtime(#[source] anyhow::Error),
+}
 
 sol! {
     event FundsReceived(uint64 indexed eventId, address indexed sender, address[] tokens, uint256[] amounts, bytes[] keys);
@@ -163,17 +195,56 @@ pub async fn listen<App: KolmeApp>(
         contract.address()
     );
 
-    listen_with_ws_retry(
-        &kolme,
-        &secret,
-        ethereum_chain,
-        &contract,
-        &subscriber_hint,
-        &mut next_bridge_event_id,
-        &mut next_block,
-        &mut first_log_index,
-    )
-    .await
+    let contract_address = *contract.address();
+    let poll_interval = match ethereum_chain {
+        EthereumChain::Local => POLL_INTERVAL_LOCAL,
+        EthereumChain::Mainnet | EthereumChain::Sepolia => POLL_INTERVAL_DEFAULT,
+    };
+
+    // Run subscriber loop
+    let mut subscriber_supervisor_guard = SubscriberTaskGuard::default();
+    let subscriber_supervisor = {
+        let kolme = kolme.clone();
+        let secret = secret.clone();
+        let subscriber_hint = subscriber_hint.clone();
+        tokio::spawn(async move {
+            subscriber_loop(
+                &kolme,
+                &secret,
+                ethereum_chain,
+                contract_address,
+                &subscriber_hint,
+            )
+            .await;
+        })
+    };
+    subscriber_supervisor_guard.set(subscriber_supervisor);
+
+    // Run poller loop concurrently
+    let poller_result = loop {
+        if let Err(e) = listen_polling_once(
+            &kolme,
+            &secret,
+            chain,
+            &contract,
+            &subscriber_hint,
+            &mut next_bridge_event_id,
+            &mut next_block,
+            &mut first_log_index,
+        )
+        .await
+        {
+            break Err(e);
+        }
+        tokio::time::sleep(poll_interval).await;
+    };
+
+    if let Some(subscriber_supervisor) = subscriber_supervisor_guard.take() {
+        subscriber_supervisor.abort();
+        let _ = subscriber_supervisor.await;
+    }
+
+    poller_result
 }
 
 async fn connect_ws(
@@ -192,95 +263,55 @@ async fn connect_ws(
     ))
 }
 
-#[allow(clippy::too_many_arguments)]
-async fn listen_with_ws_retry<App: KolmeApp, P: Provider>(
+async fn subscriber_loop<App: KolmeApp>(
     kolme: &Kolme<App>,
     secret: &SecretKey,
     ethereum_chain: EthereumChain,
-    contract: &ContractInstance<P>,
+    contract_address: Address,
     subscriber_hint: &SubscriberHintState,
-    next_bridge_event_id: &mut BridgeEventId,
-    next_block: &mut u64,
-    first_log_index: &mut Option<u64>,
-) -> Result<()> {
+) {
     let chain: ExternalChain = ethereum_chain.into();
-    let contract_address = *contract.address();
-    let poll_interval = match ethereum_chain {
-        EthereumChain::Local => POLL_INTERVAL_LOCAL,
-        EthereumChain::Mainnet | EthereumChain::Sepolia => POLL_INTERVAL_DEFAULT,
-    };
+    let mut failures = 0u32;
     let mut next_ws_retry = tokio::time::Instant::now();
-    let mut subscriber_task: Option<tokio::task::JoinHandle<()>> = None;
 
-    let result = loop {
-        // Every WS_RETRY_INTERVAL seconds, check whether subscriber task is running.
-        // If there is none, spawn one.
-        if subscriber_task
-            .as_ref()
-            .is_some_and(tokio::task::JoinHandle::is_finished)
-        {
-            if let Some(handle) = subscriber_task.take() {
-                if let Err(e) = handle.await {
-                    tracing::warn!(
-                        "Ethereum listener subscriber task join failed on chain {chain:?}: {e}"
-                    );
-                }
-            }
-        }
+    loop {
+        tokio::time::sleep_until(next_ws_retry).await;
+        next_ws_retry = tokio::time::Instant::now() + WS_RETRY_INTERVAL;
 
-        if tokio::time::Instant::now() >= next_ws_retry {
-            next_ws_retry = tokio::time::Instant::now() + WS_RETRY_INTERVAL;
-            if subscriber_task.is_none() {
-                let kolme = kolme.clone();
-                let secret = secret.clone();
-                let subscriber_hint = subscriber_hint.clone();
-                subscriber_task = Some(tokio::spawn(async move {
-                    if let Err(e) = try_ws_session_once(
-                        &kolme,
-                        &secret,
-                        ethereum_chain,
-                        contract_address,
-                        &subscriber_hint,
-                    )
-                    .await
-                    {
-                        tracing::debug!(
-                            "Ethereum listener subscriber session ended on chain {chain:?}: {e}"
-                        );
-                    }
-                }));
-            }
-        }
-
-        if let Err(e) = listen_polling_once(
+        match try_ws_session_once(
             kolme,
             secret,
-            chain,
-            contract,
+            ethereum_chain,
+            contract_address,
             subscriber_hint,
-            next_bridge_event_id,
-            next_block,
-            first_log_index,
         )
         .await
         {
-            break Err(e);
-        }
-        tokio::time::sleep(poll_interval).await;
-    };
-
-    if let Some(handle) = subscriber_task.take() {
-        handle.abort();
-        if let Err(e) = handle.await {
-            if !e.is_cancelled() {
-                tracing::warn!(
-                    "Ethereum listener subscriber task join failed on chain {chain:?}: {e}"
+            Ok(()) => {
+                failures = 0;
+            }
+            Err(SubscriberSessionError::Startup(e)) => {
+                failures = failures.saturating_add(1);
+                tracing::debug!(
+                    "Ethereum listener subscriber startup failed on chain {chain:?}: {e}"
+                );
+            }
+            Err(SubscriberSessionError::Runtime(e)) => {
+                failures = 0;
+                tracing::debug!(
+                    "Ethereum listener subscriber session ended on chain {chain:?}: {e}"
                 );
             }
         }
-    }
 
-    result
+        if failures >= SUBSCRIBER_MAX_RETRIES {
+            tracing::warn!(
+                "Disabling Ethereum listener subscriber after {} failed sessions on chain {chain:?}; polling continues",
+                SUBSCRIBER_MAX_RETRIES
+            );
+            return;
+        }
+    }
 }
 
 async fn try_ws_session_once<App: KolmeApp>(
@@ -289,7 +320,7 @@ async fn try_ws_session_once<App: KolmeApp>(
     ethereum_chain: EthereumChain,
     contract_address: Address,
     subscriber_hint: &SubscriberHintState,
-) -> Result<()> {
+) -> Result<(), SubscriberSessionError> {
     let chain: ExternalChain = ethereum_chain.into();
     let ws_contract = match connect_ws(ethereum_chain, contract_address).await {
         Ok(ws_contract) => {
@@ -305,18 +336,29 @@ async fn try_ws_session_once<App: KolmeApp>(
                 contract_address,
                 WS_RETRY_INTERVAL.as_secs()
             );
-            return Err(e);
+            return Err(SubscriberSessionError::Startup(e));
         }
     };
 
     if let Err(e) =
         listen_with_subscription(kolme, secret, chain, &ws_contract, subscriber_hint).await
     {
-        tracing::warn!(
-            "Ethereum listener subscription failed on chain {chain:?}, contract {:#x}: {e}; continuing with polling and retrying WS in {}s",
-            ws_contract.address(),
-            WS_RETRY_INTERVAL.as_secs()
-        );
+        match &e {
+            SubscriberSessionError::Startup(_) => {
+                tracing::warn!(
+                    "Ethereum listener could not start WebSocket subscription on chain {chain:?}, contract {:#x}: {e}; continuing with polling and retrying WS in {}s",
+                    ws_contract.address(),
+                    WS_RETRY_INTERVAL.as_secs()
+                );
+            }
+            SubscriberSessionError::Runtime(_) => {
+                tracing::warn!(
+                    "Ethereum listener subscription failed on chain {chain:?}, contract {:#x}: {e}; continuing with polling and retrying WS in {}s",
+                    ws_contract.address(),
+                    WS_RETRY_INTERVAL.as_secs()
+                );
+            }
+        }
         return Err(e);
     }
 
@@ -325,10 +367,10 @@ async fn try_ws_session_once<App: KolmeApp>(
         ws_contract.address(),
         WS_RETRY_INTERVAL.as_secs()
     );
-    anyhow::bail!(
+    Err(SubscriberSessionError::Runtime(anyhow::anyhow!(
         "Ethereum listener subscription ended on chain {chain:?}, contract {:#x}",
         ws_contract.address()
-    );
+    )))
 }
 
 pub async fn sanity_check_contract(
@@ -386,19 +428,25 @@ async fn listen_with_subscription<App: KolmeApp, P: Provider>(
     chain: ExternalChain,
     contract: &ContractInstance<P>,
     subscriber_hint: &SubscriberHintState,
-) -> Result<()> {
+) -> Result<(), SubscriberSessionError> {
     let filter = Filter::new()
         .from_block(BlockNumberOrTag::Latest)
         .address(*contract.address())
         .event_signature(FundsReceived::SIGNATURE_HASH);
-    let sub = contract.provider().subscribe_logs(&filter).await?;
+    let sub = contract
+        .provider()
+        .subscribe_logs(&filter)
+        .await
+        .map_err(|e| SubscriberSessionError::Startup(anyhow::Error::from(e)))?;
     let mut stream = sub.into_stream();
 
     while let Some(log) = stream.next().await {
         if log.removed {
             continue;
         }
-        if let Some(event) = EthereumBridgeEvent::from_log(&log)? {
+        if let Some(event) =
+            EthereumBridgeEvent::from_log(&log).map_err(SubscriberSessionError::Runtime)?
+        {
             if let Some(block_number) = log.block_number {
                 let mut hints = subscriber_hint.write().await;
                 hints.push_back(SubscriberHint {

--- a/packages/kolme/src/listener/ethereum.rs
+++ b/packages/kolme/src/listener/ethereum.rs
@@ -1,4 +1,4 @@
-use crate::utils::ethereum::token_address_to_denom;
+use crate::utils::ethereum::{token_address_to_denom, DEFAULT_ETHEREUM_CONFIRMATION_DEPTH};
 use crate::*;
 use alloy::{
     contract::{ContractInstance, Interface},
@@ -429,7 +429,12 @@ async fn listen_polling_once<App: KolmeApp, P: Provider>(
         .get_chain_states()
         .get(chain)
         .ok()
-        .and_then(|state| state.config.confirmation_depth);
+        .map(|state| match state.config.confirmation_depth {
+            ConfirmationDepth::UseDefault => Some(DEFAULT_ETHEREUM_CONFIRMATION_DEPTH),
+            ConfirmationDepth::Disabled => None,
+            ConfirmationDepth::Value(depth) => Some(depth),
+        })
+        .unwrap_or(Some(DEFAULT_ETHEREUM_CONFIRMATION_DEPTH));
 
     let latest = contract.provider().get_block_number().await?;
 

--- a/packages/kolme/src/listener/ethereum.rs
+++ b/packages/kolme/src/listener/ethereum.rs
@@ -212,7 +212,7 @@ async fn listen_with_ws_retry<App: KolmeApp, P: Provider>(
     let mut next_ws_retry = tokio::time::Instant::now();
     let mut subscriber_task: Option<tokio::task::JoinHandle<()>> = None;
 
-    loop {
+    let result = loop {
         // Every WS_RETRY_INTERVAL seconds, check whether subscriber task is running.
         // If there is none, spawn one.
         if subscriber_task
@@ -252,7 +252,7 @@ async fn listen_with_ws_retry<App: KolmeApp, P: Provider>(
             }
         }
 
-        listen_polling_once(
+        if let Err(e) = listen_polling_once(
             kolme,
             secret,
             chain,
@@ -262,9 +262,25 @@ async fn listen_with_ws_retry<App: KolmeApp, P: Provider>(
             next_block,
             first_log_index,
         )
-        .await?;
+        .await
+        {
+            break Err(e);
+        }
         tokio::time::sleep(poll_interval).await;
+    };
+
+    if let Some(handle) = subscriber_task.take() {
+        handle.abort();
+        if let Err(e) = handle.await {
+            if !e.is_cancelled() {
+                tracing::warn!(
+                    "Ethereum listener subscriber task join failed on chain {chain:?}: {e}"
+                );
+            }
+        }
     }
+
+    result
 }
 
 async fn try_ws_session_once<App: KolmeApp>(

--- a/packages/kolme/src/utils/ethereum.rs
+++ b/packages/kolme/src/utils/ethereum.rs
@@ -17,6 +17,7 @@ pub const ACTION_EXECUTE: u8 = 0;
 pub const ACTION_SELF_REPLACE: u8 = 1;
 pub const ACTION_NEW_SET: u8 = 2;
 pub const ETH_NATIVE_DENOM: &str = "eth";
+pub const DEFAULT_ETHEREUM_CONFIRMATION_DEPTH: u64 = 30;
 
 sol! {
     struct ExecuteAction {


### PR DESCRIPTION
Task: https://fpcomplete.atlassian.net/browse/KOL-91

- add `confirmation_depth`(`Option<u64>`) field to `ChainConfig`
- in Ethereum listener, poller now is the single source of data
- Ethereum subscriber now forms a FIFO-queue of hints - these hints are used by poller to skip chunks of blocks
- in existing integration tests for Ethereum, explicitly configure confirmation_depth to `None`
- add one more integration test with `confirmation_depth` set to `1`, and inside this test ensure that event is not processed until extra block is generated
- update docs accordingly